### PR TITLE
Mysql rerun dead jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - run: cargo test --features mysql
+      - run: cargo test --no-default-features --features mysql,migrate
         working-directory: packages/apalis-sql
         env:
           DATABASE_URL: mysql://test:test@localhost/test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,32 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+  
+  test-mysql:
+    name: Test Suite with MySQL
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_DATABASE: test
+          MYSQL_USER: test
+          MYSQL_PASSWORD: test
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: cargo test --features mysql
+        working-directory: packages/apalis-sql
+        env:
+          DATABASE_URL: mysql://test:test@localhost/test
+
 
   fmt:
     name: Rustfmt

--- a/packages/apalis-sql/Cargo.toml
+++ b/packages/apalis-sql/Cargo.toml
@@ -34,6 +34,7 @@ async-trait = "0.1.53"
 [dev-dependencies]
 tokio = { version = "1", features = ["macros"] }
 email-service = { path = "../../examples/email-service"}
+once_cell = "1.14.0"
 
 [package.metadata.docs.rs]
 # defines the configuration attribute `docsrs`

--- a/packages/apalis-sql/src/mysql.rs
+++ b/packages/apalis-sql/src/mysql.rs
@@ -483,7 +483,6 @@ mod tests {
     use email_service::Email;
     use futures::StreamExt;
 
-
     async fn setup<'a>() -> MutexGuard<'a, MysqlStorage<Email>> {
         static INSTANCE: OnceCell<Mutex<MysqlStorage<Email>>> = OnceCell::new();
         let mutex = INSTANCE.get_or_init(|| {

--- a/packages/apalis-sql/src/mysql.rs
+++ b/packages/apalis-sql/src/mysql.rs
@@ -77,7 +77,7 @@ impl<T: DeserializeOwned + Send + Unpin + Job> MysqlStorage<T> {
 
                 let job_type = T::NAME;
                 let fetch_query = "SELECT * FROM jobs
-                    WHERE status = 'Pending' AND run_at < NOW() AND job_type = ? ORDER BY run_at ASC LIMIT 1 FOR UPDATE";
+                    WHERE status = 'Pending' AND run_at <= NOW() AND job_type = ? ORDER BY run_at ASC LIMIT 1 FOR UPDATE";
                 let job: Option<SqlJobRequest<T>> = sqlx::query_as(fetch_query)
                     .bind(job_type)
                     .fetch_optional(&mut tx)


### PR DESCRIPTION
Closes #5 

This PR implements missing feature to re-run dead jobs for MySQL backends.

# Tests
I added unit tests for this feature. The scenario is the following steps. 

## Scenario 1
1. Push a job
2. Register a worker with `last_seen = (6 minutes ago)`.
3. Pull the job by the worker.
4. Call `heartbeat` with `ReenqueueOrphaned`.
5. Assert that the job status is reset to `Pending`.

## Scenario 2
1. Push a job
2. Register a worker with `last_seen = (4 minutes ago)`.
3. Pull the job by the worker.
4. Call `heartbeat` with `ReenqueueOrphaned`.
5. Assert that the job status is not changed.



# Other changes
- Extracted method `keep_alive_at(worker_id, last_seen)` from `keep_alive(worker_id)` to improve testability  
- Modified the condition `run_at < NOW()` in `stream_jobs` to `run_at <= NOW()`, because jobs cannot be pulled immediately after pushed.
- Added `Test Suite with MySQL` action to `ci.yaml` to execute unit tests with MySQL.