### PR TITLE
s/Kill/Killed/ in storage.kill

### DIFF
--- a/packages/apalis-sql/src/mysql.rs
+++ b/packages/apalis-sql/src/mysql.rs
@@ -258,7 +258,7 @@ where
             .acquire()
             .await
             .map_err(|e| StorageError::Connection(Box::from(e)))?;
-        let query = "UPDATE jobs SET status = 'Kill', done_at = NOW() WHERE id = ? AND lock_by = ?";
+        let query = "UPDATE jobs SET status = 'Killed', done_at = NOW() WHERE id = ? AND lock_by = ?";
         sqlx::query(query)
             .bind(job_id.to_owned())
             .bind(worker_id.to_owned())

--- a/packages/apalis-sql/src/mysql.rs
+++ b/packages/apalis-sql/src/mysql.rs
@@ -258,7 +258,8 @@ where
             .acquire()
             .await
             .map_err(|e| StorageError::Connection(Box::from(e)))?;
-        let query = "UPDATE jobs SET status = 'Killed', done_at = NOW() WHERE id = ? AND lock_by = ?";
+        let query =
+            "UPDATE jobs SET status = 'Killed', done_at = NOW() WHERE id = ? AND lock_by = ?";
         sqlx::query(query)
             .bind(job_id.to_owned())
             .bind(worker_id.to_owned())

--- a/packages/apalis-sql/src/postgres.rs
+++ b/packages/apalis-sql/src/postgres.rs
@@ -219,7 +219,7 @@ where
             .await
             .map_err(|e| StorageError::Database(Box::from(e)))?;
         let query =
-                "UPDATE apalis.jobs SET status = 'Kill', done_at = now() WHERE id = $1 AND lock_by = $2";
+                "UPDATE apalis.jobs SET status = 'Killed', done_at = now() WHERE id = $1 AND lock_by = $2";
         sqlx::query(query)
             .bind(job_id.to_owned())
             .bind(worker_id.to_owned())

--- a/packages/apalis-sql/src/sqlite.rs
+++ b/packages/apalis-sql/src/sqlite.rs
@@ -257,7 +257,7 @@ where
             .await
             .map_err(|e| StorageError::Database(Box::from(e)))?;
         let query =
-                "UPDATE Jobs SET status = 'Kill', done_at = strftime('%s','now') WHERE id = ?1 AND lock_by = ?2";
+                "UPDATE Jobs SET status = 'Killed', done_at = strftime('%s','now') WHERE id = ?1 AND lock_by = ?2";
         sqlx::query(query)
             .bind(job_id.to_owned())
             .bind(worker_id.to_owned())


### PR DESCRIPTION
This PR fixes a bug with killing a job.

# Bug details
In MySQL/Postgres/Sqlite3 backends, `Storage::kill(self, worker_id, job_id)` sets the status to `'Kill'`, which is incompatible to the definition of `JobStatus::Killed`.
https://github.com/geofmureithi/apalis/blob/3cfc8df9a9bcb288ea24c3892e2446c45247b947/packages/apalis-core/src/request.rs#L12-L26

As a result, deserialization of job context will panic while converting `Kill` to `JobState`. https://github.com/geofmureithi/apalis/blob/3cfc8df9a9bcb288ea24c3892e2446c45247b947/packages/apalis-sql/src/from_row.rs#L53