### PR TITLE
Add Integration Tests for Postgres backend

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
         ports:
           - 5432:5432
     env:
-      DATABASE_URL: postgres://posgres:postgres@localhost/postgres
+      DATABASE_URL: postgres://postgres:postgres@localhost/postgres
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
     name: Test Suite with Postgres
     runs-on: ubuntu-latest
     services:
-      mysql:
+      postgres:
         image: postgres:14
         env:
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,27 @@ jobs:
         env:
           DATABASE_URL: mysql://test:test@localhost/test
 
+  test-postgres:
+    name: Test Suite with Postgres
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: postgres:14
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: postgres://posgres:postgres@localhost/postgres
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: cargo test --no-default-features --features postgres,migrate
+        working-directory: packages/apalis-sql
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - run: cargo test --no-default-features --features postgres,migrate
+      - run: cargo test --no-default-features --features postgres,migrate -- --test-threads=1
         working-directory: packages/apalis-sql
 
   fmt:

--- a/packages/apalis-sql/src/postgres.rs
+++ b/packages/apalis-sql/src/postgres.rs
@@ -494,9 +494,12 @@ mod tests {
         }
     }
 
-    async fn cleanup(storage: &mut PostgresStorage<Email>, worker_id: String)
-    {
-        let mut tx = storage.pool.acquire().await.expect("failed to get connection");
+    async fn cleanup(storage: &mut PostgresStorage<Email>, worker_id: String) {
+        let mut tx = storage
+            .pool
+            .acquire()
+            .await
+            .expect("failed to get connection");
         sqlx::query("Delete from apalis.jobs where lock_by = $1 or status = 'Pending'")
             .bind(worker_id.clone())
             .execute(&mut tx)
@@ -524,8 +527,10 @@ mod tests {
             .expect("no job is pending")
     }
 
-    async fn register_worker_at(storage: &mut PostgresStorage<Email>, last_seen: DateTime<Utc>) -> String
-    {
+    async fn register_worker_at(
+        storage: &mut PostgresStorage<Email>,
+        last_seen: DateTime<Utc>,
+    ) -> String {
         let worker_id = Uuid::new_v4().to_string();
 
         storage
@@ -535,8 +540,7 @@ mod tests {
         worker_id
     }
 
-    async fn register_worker(storage: &mut PostgresStorage<Email>) -> String
-    {
+    async fn register_worker(storage: &mut PostgresStorage<Email>) -> String {
         register_worker_at(storage, Utc::now()).await
     }
 
@@ -646,7 +650,10 @@ mod tests {
         assert!(job.context().done_at().is_none());
         assert!(job.context().lock_by().is_none());
         assert!(job.context().lock_at().is_none());
-        assert_eq!(*job.context().last_error(), Some("Job was abandoned".to_string()));
+        assert_eq!(
+            *job.context().last_error(),
+            Some("Job was abandoned".to_string())
+        );
 
         cleanup(storage, worker_id).await;
     }

--- a/packages/apalis-sql/src/postgres.rs
+++ b/packages/apalis-sql/src/postgres.rs
@@ -475,9 +475,11 @@ mod tests {
         // Because connections cannot be shared across async runtime
         // (different runtimes are created for each test),
         // we don't share the storage and tests must be run sequentially.
-        PostgresStorage::connect(db_url)
+        let storage = PostgresStorage::connect(db_url)
             .await
-            .expect("failed to connect DB server")
+            .expect("failed to connect DB server");
+        storage.setup().await.expect("failed to migrate DB");
+        storage
     }
 
     /// rollback DB changes made by tests.

--- a/packages/apalis-sql/src/postgres.rs
+++ b/packages/apalis-sql/src/postgres.rs
@@ -503,11 +503,17 @@ mod tests {
     #[tokio::test]
     async fn test_consume_last_pushed_job() {
         let mut storage = setup().await;
-        storage.push(example_email()).await.expect("failed to push a job");
+        storage
+            .push(example_email())
+            .await
+            .expect("failed to push a job");
 
         let worker_id = Uuid::new_v4().to_string();
 
-        storage.keep_alive::<DummyService>(worker_id.clone()).await.expect("failed to register worker");
+        storage
+            .keep_alive::<DummyService>(worker_id.clone())
+            .await
+            .expect("failed to register worker");
 
         let job = consume_one(storage.deref_mut(), worker_id.clone()).await;
 
@@ -519,17 +525,30 @@ mod tests {
     #[tokio::test]
     async fn test_acknowledge_job() {
         let mut storage = setup().await;
-        storage.push(example_email()).await.expect("failed to push a job");
+        storage
+            .push(example_email())
+            .await
+            .expect("failed to push a job");
 
         let worker_id = Uuid::new_v4().to_string();
 
-        storage.keep_alive::<DummyService>(worker_id.clone()).await.expect("failed to register worker");
+        storage
+            .keep_alive::<DummyService>(worker_id.clone())
+            .await
+            .expect("failed to register worker");
 
         let job = consume_one(storage.deref_mut(), worker_id.clone()).await;
 
-        storage.ack(worker_id.clone(), job.context().id()).await.expect("failed to acknowledge the job");
+        storage
+            .ack(worker_id.clone(), job.context().id())
+            .await
+            .expect("failed to acknowledge the job");
 
-        let job = storage.fetch_by_id(job.context().id()).await.unwrap().unwrap();
+        let job = storage
+            .fetch_by_id(job.context().id())
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(*job.context().status(), JobState::Done);
         assert!(job.context().done_at().is_some());
     }


### PR DESCRIPTION
Part of #9 

This PR adds `Test Suite with Postgres` action and implements 5 tests for Postgres backend.

# Tests
- test_consume_last_pushed_job
- test_acknowledge_job
- test_kill_job
- test_heartbeat_renqueueorphaned_pulse_last_seen_6min
- test_heartbeat_renqueueorphaned_pulse_last_seen_4min

# Other changes
## Refactoring
I extracted `keep_alive_at(self, worker_id, last_seen)` from `keep_alive(self, worker_id)` to improve testability.

## Changed SQL statement to upsert worker in `keep_alive`:
When `keep_alive_at(self, worker_id, last_seen)` is called for `worker_id` already registered, the `last_seen` column of the worker row is updated with `NOW()` (system clock on the Postgres server).
Although this behavior was trivial things, the value of `last_seen` can be different from the current time due to the refactoring. 

Therefore, I changed the updated value to `EXCLUDED.last_seen`, which is the same value as it is inserted if the `worker_id` is registered at first time. 

```diff
 ON CONFLICT (id) DO
-  UPDATE SET last_seen = NOW()
+  UPDATE SET last_seen = EXCLUDED.last_seen
```

