### PR TITLE
Add more tests for MySQL backend

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - run: cargo test --no-default-features --features mysql,migrate
+      - run: cargo test --no-default-features --features mysql,migrate -- --test-threads=1
         working-directory: packages/apalis-sql
         env:
           DATABASE_URL: mysql://test:test@localhost/test

--- a/packages/apalis-sql/src/mysql.rs
+++ b/packages/apalis-sql/src/mysql.rs
@@ -474,14 +474,15 @@ impl<J: 'static + Job + Serialize + DeserializeOwned> JobStreamExt<J> for MysqlS
 #[cfg(test)]
 mod tests {
 
-
     use super::*;
     use email_service::Email;
     use futures::StreamExt;
 
     async fn setup() -> MysqlStorage<Email> {
         let db_url = &std::env::var("DATABASE_URL").expect("No DATABASE_URL is specified");
-        let storage = MysqlStorage::connect(db_url).await.expect("DATABASE_URL is wrong");
+        let storage = MysqlStorage::connect(db_url)
+            .await
+            .expect("DATABASE_URL is wrong");
         storage.setup().await.expect("failed to migrate DB");
         storage
     }


### PR DESCRIPTION
This PR fixes the issue sharing the connection pool on MySQL backend, and adds more tests for MySQL backend.

This PR also contains a bug fix that `lock_at` is not updated when a job is locked. (See `stream_jobs` method)