### PR TITLE
add cd.yaml

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,80 @@
+on:
+  push:
+    tags: ['v*']
+
+name: Continuous delivery
+
+jobs:
+  test:
+    uses: ./.github/workflows/ci.yaml
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    needs: [test]
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: install cargo-get
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-get
+      - name: set variables
+        run: |
+          # vX.Y.Z is release version
+          # vX.Y.Z-foo is pre-release version
+          VERSION=${GITHUB_REF#refs/tags/v}
+          VERSION_NUMBER=${VERSION%-*}
+          PUBLISH_OPTS="--dry-run"
+          if [[ $VERSION == $VERSION_NUMBER ]]; then
+            PUBLISH_OPTS=""
+          fi
+          echo VERSION=${VERSION} >> $GITHUB_ENV
+          echo PUBLISH_OPTS=${PUBLISH_OPTS} >> $GITHUB_ENV
+          echo VERSION_NUMBER=${VERSION_NUMBER} >> $GITHUB_ENV
+      - name: check version integrity
+        run: |
+          ERROR=''
+          echo VERSION: ${VERSION}, VERSION_NUMBER: ${VERSION_NUMBER}
+          for dir in "." packages/apalis-{core,cron,redis,sql}; do
+            PACKAGE=$(cargo get --root $dir -n)
+            ACTUAL=$(cargo get --root $dir version)
+            if [[ $VERSION_NUMBER != $ACTUAL ]]; then
+              echo ${PACKAGE}: expected version ${VERSION_NUMBER} but found ${ACTUAL}
+              ERROR=1
+            fi
+          done
+          if [[ $ERROR ]]; then
+            exit 1
+          fi
+      - name: publish apalis-core
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: ${{ env.PUBLISH_OPTS }} -p apalis-core
+      - name: publish apalis-cron
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: ${{ env.PUBLISH_OPTS }} -p apalis-cron
+      - name: publish apalis-redis
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: ${{ env.PUBLISH_OPTS }} -p apalis-redis
+      - name: publish apalis-sql
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: ${{ env.PUBLISH_OPTS }} -p apalis-sql
+      - name: publish apalis
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: ${{ env.PUBLISH_OPTS }} -p apalis

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    branches: [master, develop]
+  pull_request:
+  workflow_call:
 
 name: Continuous integration
 


### PR DESCRIPTION
#19 
This PR adds a workflow (Continuous delivery) to publish crates to crates.io.

# Spec
## Trigger
Continuous delivery workflow is triggered by pushing tags to the remote repository.
Tag must be of the form `vX.Y.Z` or `vX.Y.Z-SUFFIX`. 
A tag with suffix means pre-release version and it enables `--dry-run` mode.

## Secrets
Please set `CARGO_REGISTRY_TOKEN` for the authentication token for crates.io.

## Jobs
- `test`
  - This job runs several tests defined in `ci.yaml`.
- `publish`
  - This job publishes crates (`apalis-core`, `apalis-cron`, `apalis-redis`, `apalis-sql`, and `apalis`) in an appropriate order.
  - If there are some inconsistencies between the tag version and a package version (written in `Cargo.toml`), the job fails before pushing the crates.

# Test
I have created `v0.3.4-rc10` tag and confirmed that the workflow succeeds.
https://github.com/autotaker/apalis/actions/runs/3355470587

# Other changes
- Trigger of `ci.yaml` is changed
  - CI for topic branch runs only after creating a pull request. (push trigger is limited to `master`/`develop`)
  - Add `workflow_call` trigger to call CI workflow from CD workflow. 




