### PR TITLE
fix(deps): upgrade to sqlx 0.6

### DIFF
--- a/packages/apalis-sql/Cargo.toml
+++ b/packages/apalis-sql/Cargo.toml
@@ -9,31 +9,37 @@ license = "MIT"
 description = "SQL Storage for Apalis: simple, extensible multithreaded background job processing for Rust"
 
 [features]
-default = [ "sqlite", "migrate" ]
-postgres = [ "sqlx/postgres", "sqlx/json", "sqlx/chrono"]
-sqlite = [ "sqlx/sqlite", "sqlx/json", "sqlx/chrono"]
-mysql = [ "sqlx/mysql", "sqlx/json", "sqlx/chrono", "sqlx/bigdecimal"]
+default = ["sqlite", "migrate"]
+postgres = ["sqlx/postgres", "sqlx/json", "sqlx/chrono"]
+sqlite = ["sqlx/sqlite", "sqlx/json", "sqlx/chrono"]
+mysql = ["sqlx/mysql", "sqlx/json", "sqlx/chrono", "sqlx/bigdecimal"]
 migrate = ["sqlx/migrate", "sqlx/macros"]
 
 [dependencies.sqlx]
-version = "0.5.13"
+version = "0.6.2"
 default-features = false
-features = [ "runtime-tokio-rustls", "uuid" ]
+features = ["runtime-tokio-rustls", "uuid"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-apalis-core = { path = "../../packages/apalis-core", version = "0.3.4", features= ["storage"],  default-features = false}
+apalis-core = { path = "../../packages/apalis-core", version = "0.3.4", features = [
+	"storage",
+], default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 async-stream = "0.3"
 tokio = "1"
 futures-lite = "1.12.0"
 async-trait = "0.1.53"
+uuid = { version = "1.2.2", default-features = false, features = [
+	"v4",
+	"fast-rng",
+] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros"] }
-email-service = { path = "../../examples/email-service"}
+email-service = { path = "../../examples/email-service" }
 once_cell = "1.14.0"
 
 [package.metadata.docs.rs]

--- a/packages/apalis-sql/src/mysql.rs
+++ b/packages/apalis-sql/src/mysql.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, Utc};
 use futures::Stream;
 use serde::{de::DeserializeOwned, Serialize};
 
-use sqlx::types::Uuid;
+use uuid::Uuid;
 use sqlx::{MySql, MySqlPool, Pool, Row};
 use std::collections::HashMap;
 use std::convert::TryInto;

--- a/packages/apalis-sql/src/postgres.rs
+++ b/packages/apalis-sql/src/postgres.rs
@@ -22,7 +22,7 @@ use futures::{FutureExt, Stream};
 use futures_lite::future;
 use serde::{de::DeserializeOwned, Serialize};
 use sqlx::postgres::PgListener;
-use sqlx::types::Uuid;
+use uuid::Uuid;
 use sqlx::{PgPool, Row};
 use std::collections::HashMap;
 use std::convert::TryInto;

--- a/packages/apalis-sql/src/sqlite.rs
+++ b/packages/apalis-sql/src/sqlite.rs
@@ -9,7 +9,7 @@ use async_stream::try_stream;
 use chrono::{DateTime, Utc};
 use futures::Stream;
 use serde::{de::DeserializeOwned, Serialize};
-use sqlx::types::Uuid;
+use uuid::Uuid;
 use sqlx::{Pool, Row, Sqlite, SqlitePool};
 use std::collections::HashMap;
 use std::convert::TryInto;


### PR DESCRIPTION
sqlx version 0.6 no longer exposes the uuid generation feature from the uuid crate, as such we need to take uuid as a dependency.

fixes #23 