### PR TITLE
Remove time 0.1 from dependency tree

### DIFF
--- a/examples/mysql/Cargo.toml
+++ b/examples/mysql/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1"
 apalis = { path = "../../", features = ["mysql"] }
 serde = "1"
 tracing-subscriber = "0.3.11"
-chrono = { version = "0.4" }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 tokio = { version = "1", features=["macros"] }
 email-service = { path = "../email-service" }
 

--- a/examples/postgres/Cargo.toml
+++ b/examples/postgres/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1"
 apalis = { path = "../../", features = ["postgres", "broker"] }
 serde = "1"
 tracing-subscriber = "0.3.11"
-chrono = { version = "0.4" }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 tokio = { version ="1", features=["macros"]}
 email-service = { path = "../email-service" }
 

--- a/examples/redis/Cargo.toml
+++ b/examples/redis/Cargo.toml
@@ -12,7 +12,7 @@ apalis = { path = "../../", features = ["redis", "extensions"] }
 serde = "1"
 env_logger = "0.7"
 tracing-subscriber = "0.3.11"
-chrono = { version = "0.4" }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 email-service = { path = "../email-service" }
 
 

--- a/examples/rest-api/Cargo.toml
+++ b/examples/rest-api/Cargo.toml
@@ -15,5 +15,5 @@ actix-web = "4"
 futures = "0.3"
 actix-cors = "0.6.1"
 serde_json = "1"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 email-service = { path = "../email-service" }

--- a/examples/sentry/Cargo.toml
+++ b/examples/sentry/Cargo.toml
@@ -14,7 +14,7 @@ tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 sentry = "0.25"
 sentry-tower = "0.25.0"
 sentry-tracing = "0.25.0"
-chrono = { version = "0.4" }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 tokio = { version = "1", features=["macros"] }
 email-service = { path = "../email-service" }
 

--- a/examples/sqlite/Cargo.toml
+++ b/examples/sqlite/Cargo.toml
@@ -11,7 +11,7 @@ tokio = { version = "1", features=["macros"] }
 apalis = { path = "../../", features = ["sqlite", "limit"] }
 serde = "1"
 tracing-subscriber = "0.3.11"
-chrono = { version = "0.4" }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 email-service = { path = "../email-service" }
 
 

--- a/examples/tracing/Cargo.toml
+++ b/examples/tracing/Cargo.toml
@@ -12,11 +12,10 @@ serde = "1"
 tokio = { version ="1", features = ["macros"]}
 env_logger = "0.7"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json"] }
-chrono = { version = "0.4" }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 email-service = { path = "../email-service" }
 
 
 [dependencies.tracing]
 default_features = false
 version = "0.1"
-

--- a/packages/apalis-core/Cargo.toml
+++ b/packages/apalis-core/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4"
 http = "0.2.7"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 strum = { version = "0.24", features = ["derive"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 tracing-futures = { version = "0.2.5", optional = true, default-features = false }
 sentry-core =  { version= "0.25.0", optional = true, default-features = false }
 metrics = { version = "0.18", optional = true, default-features = false }

--- a/packages/apalis-cron/Cargo.toml
+++ b/packages/apalis-cron/Cargo.toml
@@ -13,7 +13,7 @@ apalis-core = { path = "../../packages/apalis-core", version = "0.3.5" }
 cron = "0.11.0"
 futures = "0.3"
 tower = { version = "0.4" }
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 tokio = { version = "1", features = ["time"] }
 async-stream = "0.3.3"
 

--- a/packages/apalis-redis/Cargo.toml
+++ b/packages/apalis-redis/Cargo.toml
@@ -15,7 +15,7 @@ apalis-core = { path = "../../packages/apalis-core", version = "0.3.5", default-
 redis = { version = "0.21" , features = ["tokio-comp"] }
 serde = "1"
 log = "0.4"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 serde_json = "1"
 async-stream = "0.3"

--- a/packages/apalis-sql/Cargo.toml
+++ b/packages/apalis-sql/Cargo.toml
@@ -24,7 +24,7 @@ features = [ "runtime-tokio-rustls", "uuid" ]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 apalis-core = { path = "../../packages/apalis-core", version = "0.3.5", features= ["storage"],  default-features = false}
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 futures = "0.3"
 async-stream = "0.3"
 tokio = "1"


### PR DESCRIPTION
The transitive time 0.1 dependency gets flagged for its security vulnerabilities. This change to the active features on chrono prevents it.

Before:
```
› cargo tree -e=normal -i=time
time v0.1.43
└── chrono v0.4.23
    └── apalis-core v0.3.5 (/Users/rob/Development/forks/apalis/packages/apalis-core)
        └── apalis v0.3.5 (/Users/rob/Development/forks/apalis)
```

After:
```
 › cargo tree -e=normal -i=time
error: package ID specification `time` did not match any packages

	Did you mean `libc`?
```