### PR TITLE
chore: expose traits and defaults struct for TraceLayer

### DIFF
--- a/packages/apalis-core/src/layers/tracing/mod.rs
+++ b/packages/apalis-core/src/layers/tracing/mod.rs
@@ -13,7 +13,7 @@ use std::{
 use tower::Service;
 use tracing::{Level, Span};
 
-use self::{
+pub use self::{
     make_span::{DefaultMakeSpan, MakeSpan},
     on_failure::{DefaultOnFailure, OnFailure},
     on_request::{DefaultOnRequest, OnRequest},


### PR DESCRIPTION
Allow the usage of traits/defaults struct used for implementation of the TraceLayer.

This is to avoid redefining all layers when creating a "generic" TraceLayer. For example in this case:

```

fn trace_on_req<B>(name: String) -> impl FnMut(&JobRequest<B>, &Span){
    move |_, _| {
        tracing::event!(Level::DEBUG, "job.start: {}", name);
    }
}

fn my_trace_layer<B>() -> TraceLayer<apalis_core::layers::tracing::make_span::DefaultMakeSpan, impl for<'a, 'b> FnMut(&'a apalis::prelude::JobRequest<B>, &'b Span)> {
   TraceLayer::new().on_request(trace_on_req::<B>("my_task".into()))
}
```

We have to redefine the MakeSpan function since we don't have access to DefaultMakeSpan.