### PR TITLE
Address worker shutdown signal propagation

### DIFF
--- a/packages/apalis-core/src/worker/ready.rs
+++ b/packages/apalis-core/src/worker/ready.rs
@@ -70,7 +70,7 @@ where
         let (send, mut recv) = futures::channel::mpsc::channel::<()>(1);
         // Setup any heartbeats by the worker
         for mut beat in self.beats {
-            ctx.spawn(async move {
+            ctx.executor.spawn(async move {
                 #[cfg(feature = "async-std-comp")]
                 #[allow(unused_variables)]
                 let sleeper = crate::utils::timer::AsyncStdTimer;


### PR DESCRIPTION
A potential fix to address issue https://github.com/geofmureithi/apalis/issues/143

Tested with the modified code in the issue.

actix-web example hangs but this may be due to starting the monitor without a signal handler with actix.