### PR TITLE
feat: configurable worker set as dead

### DIFF
--- a/packages/apalis-core/src/storage/mod.rs
+++ b/packages/apalis-core/src/storage/mod.rs
@@ -116,5 +116,8 @@ pub enum StorageWorkerPulse {
     ReenqueueOrphaned {
         /// the count of orphaned jobs
         count: i32,
+        /// the duration before a worker is considered dead
+        /// and its jobs are orphaned
+        timeout_worker: Duration,
     },
 }


### PR DESCRIPTION
The idea is to be able to configure the duration after which a worker is considered as dead in order to reenque orphan jobs. Before this PR this time was fixed to 5 minutes.