### PR TITLE
feat!: configurable concurrency per worker 

### DIFF
--- a/packages/apalis-core/src/builder.rs
+++ b/packages/apalis-core/src/builder.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::{error::Error, fmt::Debug, marker::PhantomData};
 
 use futures::Stream;
@@ -140,6 +141,7 @@ where
             stream: self.source,
             service: self.layer.service(service),
             beats: self.beats,
+            max_concurrent_jobs: NonZeroUsize::new(1000).unwrap(),
         }
     }
 }

--- a/packages/apalis-core/src/lib.rs
+++ b/packages/apalis-core/src/lib.rs
@@ -216,6 +216,7 @@ pub mod mq;
 pub mod mock {
     use futures::channel::mpsc::{Receiver, Sender};
     use futures::{Stream, StreamExt};
+    use std::num::NonZeroUsize;
     use tower::Service;
 
     use crate::{
@@ -257,6 +258,7 @@ pub mod mock {
                 stream,
                 id: WorkerId::new("mock-worker"),
                 beats: Vec::new(),
+                max_concurrent_jobs: NonZeroUsize::new(1000).unwrap(),
             },
         )
     }

--- a/packages/apalis-core/src/lib.rs
+++ b/packages/apalis-core/src/lib.rs
@@ -216,7 +216,6 @@ pub mod mq;
 pub mod mock {
     use futures::channel::mpsc::{Receiver, Sender};
     use futures::{Stream, StreamExt};
-    use std::num::NonZeroUsize;
     use tower::Service;
 
     use crate::{
@@ -258,7 +257,7 @@ pub mod mock {
                 stream,
                 id: WorkerId::new("mock-worker"),
                 beats: Vec::new(),
-                max_concurrent_jobs: NonZeroUsize::new(1000).unwrap(),
+                max_concurrent_jobs: 1000,
             },
         )
     }

--- a/packages/apalis-core/src/storage/builder.rs
+++ b/packages/apalis-core/src/storage/builder.rs
@@ -36,6 +36,7 @@ pub struct WorkerConfig {
     reenqueue_orphaned: Option<(i32, Duration)>,
     buffer_size: usize,
     fetch_interval: Duration,
+    max_concurrent_jobs: usize,
 }
 
 impl Default for WorkerConfig {
@@ -46,6 +47,7 @@ impl Default for WorkerConfig {
             reenqueue_orphaned: Some((10, Duration::from_secs(10))),
             buffer_size: 1,
             fetch_interval: Duration::from_millis(50),
+            max_concurrent_jobs: 1000,
         }
     }
 }
@@ -80,6 +82,12 @@ impl WorkerConfig {
     /// This may be ignored if the storage uses pubsub
     pub fn fetch_interval(mut self, interval: Duration) -> Self {
         self.fetch_interval = interval;
+        self
+    }
+
+    /// Maximum number of jobs to run concurrently
+    pub fn max_concurrent_jobs(mut self, max_concurrent_jobs: usize) -> Self {
+        self.max_concurrent_jobs = max_concurrent_jobs;
         self
     }
 }
@@ -129,6 +137,7 @@ where
             source,
             id: worker_id,
             beats: self.beats,
+            max_concurrent_jobs: worker_config.max_concurrent_jobs,
         }
     }
 }

--- a/packages/apalis-core/src/worker/ready.rs
+++ b/packages/apalis-core/src/worker/ready.rs
@@ -19,7 +19,6 @@ use super::WorkerId;
 use super::{Worker, WorkerContext, WorkerError};
 use futures::future::{join_all, FutureExt};
 use std::fmt::Formatter;
-use std::num::NonZeroUsize;
 
 /// A worker that is ready to consume jobs
 pub struct ReadyWorker<Stream, Service> {
@@ -27,7 +26,7 @@ pub struct ReadyWorker<Stream, Service> {
     pub(crate) stream: Stream,
     pub(crate) service: Service,
     pub(crate) beats: Vec<Box<dyn HeartBeat + Send>>,
-    pub(crate) max_concurrent_jobs: NonZeroUsize,
+    pub(crate) max_concurrent_jobs: usize,
 }
 
 impl<Stream, Service> Debug for ReadyWorker<Stream, Service> {
@@ -72,7 +71,7 @@ where
         let mut stream = ctx
             .shutdown
             .graceful_stream(self.stream)
-            .ready_chunks(self.max_concurrent_jobs.get());
+            .ready_chunks(self.max_concurrent_jobs);
         let (send, mut recv) = futures::channel::mpsc::channel::<()>(1);
         // Setup any heartbeats by the worker
         for mut beat in self.beats {

--- a/packages/apalis-redis/src/storage.rs
+++ b/packages/apalis-redis/src/storage.rs
@@ -129,7 +129,7 @@ impl<T: Job> RedisStorage<T> {
     /// Connect to a redis url
     pub async fn connect<S: IntoConnectionInfo>(redis: S) -> Result<Self, RedisError> {
         let client = Client::open(redis.into_connection_info()?)?;
-        let conn = client.get_tokio_connection_manager().await?;
+        let conn = client.get_connection_manager().await?;
         Ok(Self::new(conn))
     }
 


### PR DESCRIPTION
This PR is a POC that introduce concurrency limitation per worker. 
Instead of consuming & running all tasks in a queue, you can limit the number of fetched and thus concurrent running jobs. As we can found in [celery](https://docs.celeryq.dev/en/stable/userguide/optimizing.html#prefetch-limits) 

@geofmureithi Another way to achieve that is to change the Return of `fn consume` instead of returning `JobStreamResult<T>` we can return `JobStreamResult<Vec<T>>` this way we avoid the need for an extra parameter ie `max_concurrent_jobs`. 
A worker will then fetch at most `buffer_size` jobs and run them directly and wait for all results thanks to `fn join_all`. 

- For short lived jobs you can then configure a high `buffer_size`, note today is theoretically infinite and may cause CPU/memory ressources issue
- For long running jobs you can configure a `buffer_size` of 1 allowing to scale your application or the number of worker without starving them 

Note: using a layer like `GlobalConcurrencyLimitLayer` or `ConcurrencyLimitLayer` is not enough: 
- since jobs are launched with `fn spawn` and are not awaited 1 job will be running BUT you'll continue to fetch the message queue.
- So you'll have a worker running a job, and N fetched jobs waiting to be processed. This is not ideal when you want to scale the number of apps on a K8s cluster for instance, because your Scaler need to watch a message queue and it will be seen as empty because all jobs have been fetched then you Scaler will NOT trigger any scale up. :'( 
- Some situations requires to have a most 1 worker & 1 job running top per worker. For instance (this is my use case) you're using a GPU that cannot be shared accros workers of the same running app and you need to trigger a Gpu Node Scale up in order to scale your app on another machine etc etc ...
 