### PR TITLE
Fixing MQ builder

### DIFF
--- a/packages/apalis-core/src/mq/builder.rs
+++ b/packages/apalis-core/src/mq/builder.rs
@@ -40,6 +40,7 @@ where
             source,
             id: worker_id,
             beats: self.beats,
+            max_concurrent_jobs: self.max_concurrent_jobs,
         }
     }
 }


### PR DESCRIPTION
 0.4.8 update broke Mq WorkerBuilder initialization:

```
   |
37 |         WorkerBuilder {
   |         ^^^^^^^^^^^^^ missing `max_concurrent_jobs`
```