### PR TITLE
fix: re-export apalis_redis::Config in apalis crate

### DIFF
--- a/examples/redis/src/main.rs
+++ b/examples/redis/src/main.rs
@@ -41,7 +41,8 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
     let conn = apalis::redis::connect("redis://127.0.0.1/").await?;
-    let storage = RedisStorage::new(conn);
+    let config = apalis::redis::Config::default();
+    let storage = RedisStorage::new_with_config(conn, config);
     // This can be in another part of the program
     produce_jobs(storage.clone()).await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,7 @@
 #[cfg(feature = "redis")]
 #[cfg_attr(docsrs, doc(cfg(feature = "redis")))]
 pub mod redis {
-    pub use apalis_redis::connect;
-    pub use apalis_redis::RedisStorage;
+    pub use apalis_redis::*;
 }
 
 /// Include the default Sqlite storage


### PR DESCRIPTION
apalis_redis was already exporting 3 items : 
- connect, RedisStorage & Config

But apalis was re-exporting only: 
- connect & RedisStorage