### PR TITLE
Update postgres timestamp type to bigint to match i64

### DIFF
--- a/packages/apalis-sql/migrations/postgres/20240318190637_replace_timestamp_type.sql
+++ b/packages/apalis-sql/migrations/postgres/20240318190637_replace_timestamp_type.sql
@@ -1,0 +1,10 @@
+alter table apalis.jobs
+    alter column run_at
+        drop default;
+
+alter table apalis.jobs
+alter column run_at type bigint using (extract(epoch from run_at) * 1000);
+
+alter table apalis.jobs
+    alter column run_at
+        set default (extract(epoch from now()) * 1000);


### PR DESCRIPTION
See #275 

Not sure if there's any `sqlx prepare` metadata that needs to be commited as well, I've only tested this in my client project.