### PR TITLE
Expose SqlContext  via feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,14 @@ default = ["tracing", "tokio-comp"]
 
 ## Include redis storage
 redis = ["apalis-redis"]
+## Include SQL Context
+sqlcontext = ["apalis-sql"]
 ## Include Postgres storage
-postgres = ["apalis-sql/postgres"]
+postgres = ["sqlcontext","apalis-sql/postgres"]
 ## Include SQlite storage
-sqlite = ["apalis-sql/sqlite"]
+sqlite = ["sqlcontext","apalis-sql/sqlite"]
 ## Include MySql storage
-mysql = ["apalis-sql/mysql"]
+mysql = ["sqlcontext","apalis-sql/mysql"]
 ## Include Cron functionality
 cron = ["apalis-cron"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,13 @@ pub mod redis {
     pub use apalis_redis::*;
 }
 
+/// Expose SqlContext
+#[cfg(feature = "sqlcontext")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sqlcontext")))]
+pub mod apalis_sql {
+    pub use apalis_sql::context::*;
+}
+
 /// Include the default Sqlite storage
 #[cfg(feature = "sqlite")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]


### PR DESCRIPTION
Being able to access SqlContext from applications is very useful.  This pull request enables access via a feature flag which is enabled by default if one of the sql storage types is selected.