### PR TITLE
fix: remove async-timer as a dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ limit = ["tower/limit"]
 filter = ["tower/filter"]
 ## Compatibility with async-std and smol runtimes
 async-std-comp = [
+  "apalis-core/async-std-comp",
   "apalis-sql?/async-std-comp",
   "apalis-redis?/async-std-comp",
   "apalis-cron?/async-std-comp",
@@ -52,6 +53,7 @@ async-std-comp = [
 ]
 ## Compatibility with tokio and actix runtimes
 tokio-comp = [
+  "apalis-core/tokio-comp",
   "apalis-sql?/tokio-comp",
   "apalis-redis?/tokio-comp",
   "apalis-cron?/tokio-comp",
@@ -87,7 +89,7 @@ path = "./packages/apalis-sql"
 [dependencies.apalis-core]
 version = "0.5.1"
 default-features = false
-path = "./packages/apalis-core"
+path = "packages/apalis-core"
 
 [dependencies.apalis-cron]
 version = "0.5.1"

--- a/packages/apalis-core/Cargo.toml
+++ b/packages/apalis-core/Cargo.toml
@@ -19,9 +19,10 @@ pin-project-lite = "0.2.14"
 async-oneshot = "0.5.9"
 thiserror = "1.0.58"
 ulid = { version = "1.1.2", default-features = false, features = ["std"] }
-async-timer = { version = "1.0.0-beta.13", optional = true, default-features = false }
 # Needed for the codec
 serde_json = { version = "1", optional = true }
+tokio = { version = "1", features = ["time"], default-features = false, optional = true }
+async-std = { version = "1", optional = true }
 
 [dependencies.document-features]
 version = "0.2"
@@ -31,8 +32,10 @@ optional = true
 [features]
 default = []
 docsrs = ["document-features"]
-sleep = ["async-timer"]
 json = ["serde_json"]
+async-std-comp = ["async-std"]
+## Compatibility with tokio and actix runtimes
+tokio-comp = ["tokio"]
 
 [package.metadata.docs.rs]
 # defines the configuration attribute `docsrs`

--- a/packages/apalis-core/src/lib.rs
+++ b/packages/apalis-core/src/lib.rs
@@ -100,10 +100,15 @@ pub trait Codec<T, Compact> {
 }
 
 /// Sleep utilities
-#[cfg(feature = "sleep")]
+#[cfg(feature = "tokio-comp")]
 pub async fn sleep(duration: std::time::Duration) {
-    let mut interval = async_timer::Interval::platform_new(duration);
-    interval.wait().await;
+    tokio::time::sleep(duration).await;
+}
+
+/// Sleep utilities
+#[cfg(feature = "async-std-comp")]
+pub async fn sleep(duration: std::time::Duration) {
+    async_std::task::sleep(duration).await;
 }
 
 #[cfg(test)]

--- a/packages/apalis-cron/Cargo.toml
+++ b/packages/apalis-cron/Cargo.toml
@@ -10,7 +10,6 @@ description = "A simple yet extensible library for cron-like job scheduling for 
 
 [dependencies]
 apalis-core = { path = "../../packages/apalis-core", version = "0.5.1", default-features = false, features = [
-    "sleep",
     "json",
 ] }
 cron = "0.12.1"
@@ -31,8 +30,8 @@ serde = { version = "1.0", features = ["derive"] }
 
 [features]
 default = ["tokio-comp"]
-async-std-comp = ["async-std"]
-tokio-comp = ["tokio/net"]
+async-std-comp = ["async-std", "apalis-core/async-std-comp"]
+tokio-comp = ["tokio/net", "apalis-core/tokio-comp"]
 
 [package.metadata.docs.rs]
 # defines the configuration attribute `docsrs`

--- a/packages/apalis-redis/Cargo.toml
+++ b/packages/apalis-redis/Cargo.toml
@@ -12,7 +12,6 @@ description = "Redis Storage for apalis: use Redis for background jobs and messa
 
 [dependencies]
 apalis-core = { path = "../../packages/apalis-core", version = "0.5.1", default-features = false, features = [
-    "sleep",
     "json",
 ] }
 redis = { version = "0.25", default-features = false, features = [
@@ -42,5 +41,5 @@ apalis = { path = "../../", default-features = false, features = [
 
 [features]
 default = ["tokio-comp"]
-async-std-comp = ["async-std", "redis/async-std-comp"]
-tokio-comp = ["tokio", "tokio/net", "redis/tokio-comp"]
+async-std-comp = ["async-std", "redis/async-std-comp", "apalis-core/async-std-comp"]
+tokio-comp = ["tokio", "tokio/net", "redis/tokio-comp", "apalis-core/tokio-comp"]

--- a/packages/apalis-sql/Cargo.toml
+++ b/packages/apalis-sql/Cargo.toml
@@ -14,8 +14,8 @@ postgres = ["sqlx/postgres", "sqlx/json"]
 sqlite = ["sqlx/sqlite", "sqlx/json"]
 mysql = ["sqlx/mysql", "sqlx/json", "sqlx/bigdecimal"]
 migrate = ["sqlx/migrate", "sqlx/macros"]
-async-std-comp = ["async-std", "sqlx/runtime-async-std-rustls"]
-tokio-comp = ["tokio", "sqlx/runtime-tokio-rustls"]
+async-std-comp = ["async-std", "sqlx/runtime-async-std-rustls", "apalis-core/async-std-comp"]
+tokio-comp = ["tokio", "sqlx/runtime-tokio-rustls", "apalis-core/tokio-comp"]
 
 [dependencies.sqlx]
 version = "0.7.4"
@@ -26,7 +26,6 @@ features = ["chrono"]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 apalis-core = { path = "../../packages/apalis-core", version = "0.5.1", default-features = false, features = [
-    "sleep",
     "json",
 ] }
 log = "0.4"


### PR DESCRIPTION
Use of `async-timer` can cause panic with `already borrowed: BorrowMutError`.
This issue is explained in a ticket in `tokio` project, see:
https://github.com/tokio-rs/tokio/issues/5975#issuecomment-1731921015

Only the `sleep` function in `apalis-core` uses `async-timer` and since `apalis` only supports `tokio` and `async-std` as runtimes, we can use `sleep` functions from these two runtimes directly and drop `async-timer` as a dependency.