### PR TITLE
fix: replace async-timer with futures-timer

### DIFF
--- a/packages/apalis-core/Cargo.toml
+++ b/packages/apalis-core/Cargo.toml
@@ -19,7 +19,7 @@ pin-project-lite = "0.2.14"
 async-oneshot = "0.5.9"
 thiserror = "1.0.59"
 ulid = { version = "1.1.2", default-features = false, features = ["std"] }
-async-timer = { version = "1.0.0-beta.13", optional = true, default-features = false }
+futures-timer = { version = "3.0.3", optional = true }
 # Needed for the codec
 serde_json = { version = "1", optional = true }
 
@@ -31,7 +31,7 @@ optional = true
 [features]
 default = []
 docsrs = ["document-features"]
-sleep = ["async-timer"]
+sleep = ["futures-timer"]
 json = ["serde_json"]
 
 [package.metadata.docs.rs]

--- a/packages/apalis-core/src/lib.rs
+++ b/packages/apalis-core/src/lib.rs
@@ -102,8 +102,7 @@ pub trait Codec<T, Compact> {
 /// Sleep utilities
 #[cfg(feature = "sleep")]
 pub async fn sleep(duration: std::time::Duration) {
-    let mut interval = async_timer::Interval::platform_new(duration);
-    interval.wait().await;
+    futures_timer::Delay::new(duration).await;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Attempts to resolve #291 and  #301 without a version bump