### PR TITLE
Version: 0.6.0-alpha.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ members = [
   "examples/tracing",
   # "examples/rest-api",
   "examples/async-std-runtime",
-  "examples/basics", "examples/redis-with-msg-pack",
+  "examples/basics", "examples/redis-with-msg-pack", "examples/redis-deadpool",
 ]
 
 

--- a/benches/storages.rs
+++ b/benches/storages.rs
@@ -134,7 +134,7 @@ define_bench!("sqlite_in_memory", {
 
 define_bench!("redis", {
     let conn = apalis::redis::connect(env!("REDIS_URL")).await.unwrap();
-    let redis = RedisStorage::new(conn, Config::default());
+    let redis = RedisStorage::new(conn);
     redis
 });
 

--- a/examples/actix-web/src/main.rs
+++ b/examples/actix-web/src/main.rs
@@ -2,7 +2,6 @@ use actix_web::rt::signal;
 use actix_web::{web, App, HttpResponse, HttpServer};
 use anyhow::Result;
 use apalis::prelude::*;
-use apalis::redis::Config;
 use apalis::utils::TokioExecutor;
 use apalis::{layers::tracing::TraceLayer, redis::RedisStorage};
 use futures::future;
@@ -28,7 +27,7 @@ async fn main() -> Result<()> {
     env_logger::init();
 
     let conn = apalis::redis::connect("redis://127.0.0.1/").await?;
-    let storage = RedisStorage::new(conn, Config::default());
+    let storage = RedisStorage::new(conn);
     let data = web::Data::new(storage.clone());
     let http = async {
         HttpServer::new(move || {

--- a/examples/axum/src/main.rs
+++ b/examples/axum/src/main.rs
@@ -5,7 +5,6 @@
 //! ```
 use anyhow::Result;
 use apalis::prelude::*;
-use apalis::redis::Config;
 use apalis::{layers::tracing::TraceLayer, redis::RedisStorage};
 use axum::{
     extract::Form,
@@ -57,7 +56,7 @@ async fn main() -> Result<()> {
         .with(tracing_subscriber::fmt::layer())
         .init();
     let conn = apalis::redis::connect("redis://127.0.0.1/").await?;
-    let storage = RedisStorage::new(conn, Config::default());
+    let storage = RedisStorage::new(conn);
     // build our application with some routes
     let app = Router::new()
         .route("/", get(show_form).post(add_new_job::<Email>))

--- a/examples/postgres/src/main.rs
+++ b/examples/postgres/src/main.rs
@@ -1,15 +1,13 @@
 use anyhow::Result;
 use apalis::layers::retry::RetryPolicy;
-use apalis::postgres::PgPool;
+use apalis::postgres::{PgListen, PgPool};
 use apalis::prelude::*;
 use apalis::{layers::tracing::TraceLayer, postgres::PostgresStorage};
 use email_service::{send_email, Email};
 use tower::retry::RetryLayer;
 use tracing::{debug, info};
 
-async fn produce_jobs(storage: &PostgresStorage<Email>) -> Result<()> {
-    // The programmatic way
-    let mut storage = storage.clone();
+async fn produce_jobs(storage: &mut PostgresStorage<Email>) -> Result<()> {
     for index in 0..10 {
         storage
             .push(Email {
@@ -35,15 +33,23 @@ async fn main() -> Result<()> {
         .await
         .expect("unable to run migrations for postgres");
 
-    let pg = PostgresStorage::new(pool);
-    produce_jobs(&pg).await?;
+    let mut pg = PostgresStorage::new(pool.clone());
+    produce_jobs(&mut pg).await?;
+
+    let mut listener = PgListen::new(pool).await?;
+
+    listener.subscribe_with(&mut pg);
+
+    tokio::spawn(async move {
+        listener.listen().await.unwrap();
+    });
 
     Monitor::<TokioExecutor>::new()
         .register_with_count(4, {
             WorkerBuilder::new("tasty-orange")
                 .layer(TraceLayer::new())
                 .layer(RetryLayer::new(RetryPolicy::retries(5)))
-                .with_storage(pg.clone())
+                .with_storage(pg)
                 .build_fn(send_email)
         })
         .on_event(|e| debug!("{e:?}"))

--- a/examples/prometheus/src/main.rs
+++ b/examples/prometheus/src/main.rs
@@ -5,7 +5,6 @@
 //! ```
 use anyhow::Result;
 use apalis::prelude::*;
-use apalis::redis::Config;
 use apalis::{layers::prometheus::PrometheusLayer, redis::RedisStorage};
 use axum::{
     extract::Form,
@@ -31,7 +30,7 @@ async fn main() -> Result<()> {
         .with(tracing_subscriber::fmt::layer())
         .init();
     let conn = apalis::redis::connect("redis://127.0.0.1/").await?;
-    let storage = RedisStorage::new(conn, Config::default());
+    let storage = RedisStorage::new(conn);
     // build our application with some routes
     let recorder_handle = setup_metrics_recorder();
     let app = Router::new()

--- a/examples/redis-deadpool/Cargo.toml
+++ b/examples/redis-deadpool/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "redis-deadpool"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+deadpool-redis = { version = "0.15.1" }
+anyhow = "1"
+tokio = { version = "1", features = ["full"] }
+apalis = { path = "../../", features = ["redis", "timeout"] }
+serde = "1"
+env_logger = "0.10"
+tracing-subscriber = "0.3.11"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+email-service = { path = "../email-service" }
+rmp-serde = "1.3"
+
+
+[dependencies.tracing]
+default-features = false
+version = "0.1"

--- a/examples/redis-deadpool/src/main.rs
+++ b/examples/redis-deadpool/src/main.rs
@@ -4,12 +4,9 @@ use anyhow::Result;
 use apalis::prelude::*;
 use apalis::redis::RedisStorage;
 
-use deadpool_redis::{redis::aio::{ConnectionLike, MultiplexedConnection}, Config, Connection, Manager, Pool, Runtime};
+use deadpool_redis::{Config, Connection, Runtime};
 use email_service::{send_email, Email};
-use serde::{de::DeserializeOwned, Serialize};
 use tracing::info;
-
-
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -21,10 +18,10 @@ async fn main() -> Result<()> {
         .set_namespace("apalis::redis-dead-pool")
         .set_max_retries(5);
 
-    let mut cfg = Config::from_url("redis://127.0.0.1/");
+    let cfg = Config::from_url("redis://127.0.0.1/");
     let pool = cfg.create_pool(Some(Runtime::Tokio1)).unwrap();
     let conn = pool.get().await.unwrap();
-    let mut storage = RedisStorage::new(conn, config);
+    let mut storage = RedisStorage::new_with_config(conn, config);
     // This can be in another part of the program
     produce_jobs(&mut storage).await?;
 

--- a/examples/redis/src/main.rs
+++ b/examples/redis/src/main.rs
@@ -5,8 +5,8 @@ use std::{
 };
 
 use anyhow::Result;
+use apalis::prelude::*;
 use apalis::redis::RedisStorage;
-use apalis::{prelude::*, redis::Config};
 
 use email_service::{send_email, Email};
 use tracing::{error, info};
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
     let conn = apalis::redis::connect("redis://127.0.0.1/").await?;
-    let storage = RedisStorage::new(conn, Config::default());
+    let storage = RedisStorage::new(conn);
     // This can be in another part of the program
     produce_jobs(storage.clone()).await?;
 

--- a/examples/sentry/src/main.rs
+++ b/examples/sentry/src/main.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use apalis::{
     layers::{sentry::SentryLayer, tracing::TraceLayer},
     prelude::*,
-    redis::{Config, RedisStorage},
+    redis::RedisStorage,
 };
 use email_service::Email;
 use tokio::time::sleep;
@@ -130,7 +130,7 @@ async fn main() -> Result<()> {
         .init();
 
     let conn = apalis::redis::connect(redis_url).await?;
-    let storage = RedisStorage::new(conn, Config::default());
+    let storage = RedisStorage::new(conn);
     //This can be in another part of the program
     produce_jobs(storage.clone()).await?;
 

--- a/examples/tracing/src/main.rs
+++ b/examples/tracing/src/main.rs
@@ -8,7 +8,7 @@ use tracing_subscriber::prelude::*;
 use apalis::{
     layers::tracing::TraceLayer,
     prelude::{Monitor, Storage, WorkerBuilder, WorkerFactoryFn},
-    redis::{Config, RedisStorage},
+    redis::RedisStorage,
     utils::TokioExecutor,
 };
 
@@ -66,7 +66,7 @@ async fn main() -> Result<()> {
     let conn = apalis::redis::connect(redis_url)
         .await
         .expect("Could not connect to RedisStorage");
-    let storage = RedisStorage::new(conn, Config::default());
+    let storage = RedisStorage::new(conn);
     //This can be in another part of the program
     produce_jobs(storage.clone()).await?;
 

--- a/packages/apalis-core/src/builder.rs
+++ b/packages/apalis-core/src/builder.rs
@@ -167,8 +167,9 @@ where
     S::Future: Send,
 
     S::Response: 'static,
-    P::Layer: Layer<S>,
-    M: Layer<<P::Layer as Layer<S>>::Service>,
+    M: Layer<S>,
+    // P::Layer: Layer<S>,
+    // M: Layer<<P::Layer as Layer<S>>::Service>,
 {
     type Source = P;
 
@@ -176,9 +177,9 @@ where
     /// Build a worker, given a tower service
     fn build(self, service: S) -> Worker<Ready<Self::Service, P>> {
         let worker_id = self.id;
-        let common_layer = self.source.common_layer(worker_id.clone());
+        // let common_layer = self.source.common_layer(worker_id.clone());
         let poller = self.source;
-        let middleware = self.layer.layer(common_layer);
+        let middleware = self.layer;
         let service = middleware.service(service);
 
         Worker::new(worker_id, Ready::new(service, poller))

--- a/packages/apalis-core/src/layers.rs
+++ b/packages/apalis-core/src/layers.rs
@@ -1,6 +1,8 @@
 use std::marker::PhantomData;
 use std::{fmt, sync::Arc};
-pub use tower::{layer::layer_fn, util::BoxCloneService, Layer, Service, ServiceBuilder};
+pub use tower::{
+    layer::layer_fn, layer::util::Identity, util::BoxCloneService, Layer, Service, ServiceBuilder,
+};
 
 use futures::{future::BoxFuture, Future, FutureExt};
 
@@ -158,7 +160,7 @@ pub trait Ack<J> {
     type Error: std::error::Error;
     /// Acknowledges successful processing of the given request
     fn ack(
-        &self,
+        &mut self,
         worker_id: &WorkerId,
         data: &Self::Acknowledger,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
@@ -244,7 +246,7 @@ where
     }
 
     fn call(&mut self, request: Request<J>) -> Self::Future {
-        let ack = self.ack.clone();
+        let mut ack = self.ack.clone();
         let worker_id = self.worker_id.clone();
         let data = request.get::<<A as Ack<J>>::Acknowledger>().cloned();
 

--- a/packages/apalis-core/src/layers.rs
+++ b/packages/apalis-core/src/layers.rs
@@ -1,6 +1,5 @@
 use futures::channel::mpsc::{SendError, Sender};
 use futures::SinkExt;
-use std::future::IntoFuture;
 use std::marker::PhantomData;
 use std::{fmt, sync::Arc};
 pub use tower::{
@@ -180,7 +179,7 @@ impl<J, A: Send + Clone + 'static> Ack<J> for AckStream<A> {
         worker_id: &WorkerId,
         data: &Self::Acknowledger,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send {
-        self.0.send((worker_id.clone(), data.clone())).into_future()
+        self.0.send((worker_id.clone(), data.clone())).boxed()
     }
 }
 

--- a/packages/apalis-core/src/lib.rs
+++ b/packages/apalis-core/src/lib.rs
@@ -77,14 +77,8 @@ pub trait Backend<Req> {
     /// Returns the final decoration of layers
     type Layer;
 
-    /// Allows the backend to decorate the service with [Layer]
-    ///
-    /// [Layer]: tower::Layer
-    #[allow(unused)]
-    fn common_layer(&self, worker: WorkerId) -> Self::Layer;
-
     /// Returns a poller that is ready for streaming
-    fn poll(self, worker: WorkerId) -> Poller<Self::Stream>;
+    fn poll(self, worker: WorkerId) -> Poller<Self::Stream, Self::Layer>;
 }
 
 /// This allows encoding and decoding of requests in different backends

--- a/packages/apalis-core/src/lib.rs
+++ b/packages/apalis-core/src/lib.rs
@@ -105,6 +105,58 @@ pub async fn sleep(duration: std::time::Duration) {
     futures_timer::Delay::new(duration).await;
 }
 
+#[cfg(feature = "sleep")]
+/// Interval utilities
+pub mod interval {
+    use std::fmt;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use std::time::Duration;
+
+    use futures::future::BoxFuture;
+    use futures::Stream;
+
+    use crate::sleep;
+    /// Creates a new stream that yields at a set interval.
+    pub fn interval(duration: Duration) -> Interval {
+        Interval {
+            timer: Box::pin(sleep(duration)),
+            interval: duration,
+        }
+    }
+
+    /// A stream representing notifications at fixed interval
+    #[must_use = "streams do nothing unless polled or .awaited"]
+    pub struct Interval {
+        timer: BoxFuture<'static, ()>,
+        interval: Duration,
+    }
+
+    impl fmt::Debug for Interval {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("Interval")
+                .field("interval", &self.interval)
+                .field("timer", &"a future represented `apalis_core::sleep`")
+                .finish()
+        }
+    }
+
+    impl Stream for Interval {
+        type Item = ();
+
+        fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            match Pin::new(&mut self.timer).poll(cx) {
+                Poll::Ready(_) => {}
+                Poll::Pending => return Poll::Pending,
+            };
+            let interval = self.interval;
+            let _ = std::mem::replace(&mut self.timer, Box::pin(sleep(interval)));
+            Poll::Ready(Some(()))
+        }
+    }
+}
+
 #[cfg(test)]
 #[doc(hidden)]
 #[derive(Debug, Default, Clone)]

--- a/packages/apalis-core/src/memory.rs
+++ b/packages/apalis-core/src/memory.rs
@@ -14,7 +14,7 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
-use tower::{layer::util::Identity, ServiceBuilder};
+use tower::layer::util::Identity;
 
 #[derive(Debug)]
 /// An example of the basics of a backend
@@ -99,17 +99,14 @@ impl<T> Stream for MemoryWrapper<T> {
 impl<T: Send + 'static + Sync> Backend<Request<T>> for MemoryStorage<T> {
     type Stream = BackendStream<RequestStream<Request<T>>>;
 
-    type Layer = ServiceBuilder<Identity>;
-
-    fn common_layer(&self, _worker: WorkerId) -> Self::Layer {
-        ServiceBuilder::new()
-    }
+    type Layer = Identity;
 
     fn poll(self, _worker: WorkerId) -> Poller<Self::Stream> {
         let stream = self.inner.map(|r| Ok(Some(Request::new(r)))).boxed();
         Poller {
             stream: BackendStream::new(stream, self.controller),
             heartbeat: Box::pin(async {}),
+            layer: Identity::new(),
         }
     }
 }

--- a/packages/apalis-core/src/poller/mod.rs
+++ b/packages/apalis-core/src/poller/mod.rs
@@ -3,6 +3,7 @@ use std::{
     fmt::{self, Debug},
     ops::{Deref, DerefMut},
 };
+use tower::layer::util::Identity;
 
 /// Util for controlling pollers
 pub mod controller;
@@ -10,29 +11,46 @@ pub mod controller;
 pub mod stream;
 
 /// A poller type that allows fetching from a stream and a heartbeat future that can be used to do periodic tasks
-pub struct Poller<S> {
+pub struct Poller<S, L = Identity> {
     pub(crate) stream: S,
     pub(crate) heartbeat: BoxFuture<'static, ()>,
+    pub(crate) layer: L,
 }
 
-impl<S> Poller<S> {
+impl<S> Poller<S, Identity> {
     /// Build a new poller
     pub fn new(stream: S, heartbeat: impl Future<Output = ()> + Send + 'static) -> Self {
         Self {
             stream,
             heartbeat: heartbeat.boxed(),
+            layer: Identity::new(),
+        }
+    }
+
+    /// Build a poller with layer
+    pub fn new_with_layer<L>(
+        stream: S,
+        heartbeat: impl Future<Output = ()> + Send + 'static,
+        layer: L,
+    ) -> Poller<S, L> {
+        Poller {
+            stream,
+            heartbeat: heartbeat.boxed(),
+            layer,
         }
     }
 }
 
-impl<S> Debug for Poller<S>
+impl<S, L> Debug for Poller<S, L>
 where
     S: Debug,
+    L: Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Poller")
             .field("stream", &self.stream)
             .field("heartbeat", &"...")
+            .field("layer", &self.layer)
             .finish()
     }
 }

--- a/packages/apalis-core/src/request.rs
+++ b/packages/apalis-core/src/request.rs
@@ -1,6 +1,6 @@
 use futures::{future::BoxFuture, Stream};
 use serde::{Deserialize, Serialize};
-use tower::{layer::util::Identity, ServiceBuilder};
+use tower::layer::util::Identity;
 
 use std::{fmt::Debug, pin::Pin};
 
@@ -64,16 +64,13 @@ pub type RequestStream<T> = BoxStream<'static, Result<Option<T>, Error>>;
 impl<T> Backend<Request<T>> for RequestStream<Request<T>> {
     type Stream = Self;
 
-    type Layer = ServiceBuilder<Identity>;
-
-    fn common_layer(&self, _worker: WorkerId) -> Self::Layer {
-        ServiceBuilder::new()
-    }
+    type Layer = Identity;
 
     fn poll(self, _worker: WorkerId) -> Poller<Self::Stream> {
         Poller {
             stream: self,
             heartbeat: Box::pin(async {}),
+            layer: Identity::new(),
         }
     }
 }

--- a/packages/apalis-core/src/storage/mod.rs
+++ b/packages/apalis-core/src/storage/mod.rs
@@ -33,17 +33,17 @@ pub trait Storage: Backend<Request<Self::Job>> {
     ) -> impl Future<Output = Result<Self::Identifier, Self::Error>> + Send;
 
     /// Return the number of pending jobs from the queue
-    fn len(&self) -> impl Future<Output = Result<i64, Self::Error>> + Send;
+    fn len(&mut self) -> impl Future<Output = Result<i64, Self::Error>> + Send;
 
     /// Fetch a job given an id
     fn fetch_by_id(
-        &self,
+        &mut self,
         job_id: &Self::Identifier,
     ) -> impl Future<Output = Result<Option<Request<Self::Job>>, Self::Error>> + Send;
 
     /// Update a job details
     fn update(
-        &self,
+        &mut self,
         job: Request<Self::Job>,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
@@ -55,8 +55,8 @@ pub trait Storage: Backend<Request<Self::Job>> {
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
     /// Returns true if there is no jobs in the storage
-    fn is_empty(&self) -> impl Future<Output = Result<bool, Self::Error>> + Send;
+    fn is_empty(&mut self) -> impl Future<Output = Result<bool, Self::Error>> + Send;
 
     /// Vacuum the storage, removes done and killed jobs
-    fn vacuum(&self) -> impl Future<Output = Result<usize, Self::Error>> + Send;
+    fn vacuum(&mut self) -> impl Future<Output = Result<usize, Self::Error>> + Send;
 }

--- a/packages/apalis-core/src/storage/mod.rs
+++ b/packages/apalis-core/src/storage/mod.rs
@@ -8,7 +8,6 @@ use crate::{request::Request, Backend};
 pub type StorageStream<T, E> = BoxStream<'static, Result<Option<Request<T>>, E>>;
 
 /// Represents a [Storage] that can persist a request.
-/// The underlying type must implement [Job]
 pub trait Storage: Backend<Request<Self::Job>> {
     /// The type of job that can be persisted
     type Job;

--- a/packages/apalis-core/src/worker/stream.rs
+++ b/packages/apalis-core/src/worker/stream.rs
@@ -4,7 +4,6 @@ use std::task::{Context, Poll};
 
 use super::WorkerNotify;
 
-// Define your struct
 pub(crate) struct WorkerStream<T, S>
 where
     S: Stream<Item = T>,

--- a/packages/apalis-redis/src/lib.rs
+++ b/packages/apalis-redis/src/lib.rs
@@ -14,7 +14,7 @@
 //! #[tokio::main]
 //! async fn main() {
 //!     let conn = apalis::redis::connect("redis://127.0.0.1/").await.unwrap();
-//!     let storage = RedisStorage::new(conn, Config::default());
+//!     let storage = RedisStorage::new(conn);
 //!     Monitor::<TokioExecutor>::new()
 //!        .register(
 //!            WorkerBuilder::new("tasty-pear")

--- a/packages/apalis-redis/src/storage.rs
+++ b/packages/apalis-redis/src/storage.rs
@@ -890,7 +890,6 @@ impl<T, Conn: ConnectionLike + Send + Sync + 'static> RedisStorage<T, Conn> {
 #[cfg(test)]
 mod tests {
     use email_service::Email;
-    use futures::StreamExt;
 
     use super::*;
 
@@ -901,7 +900,7 @@ mod tests {
         // (different runtimes are created for each test),
         // we don't share the storage and tests must be run sequentially.
         let conn = connect(redis_url).await.unwrap();
-        let storage = RedisStorage::new(conn, Config::default());
+        let storage = RedisStorage::new(conn);
         storage
     }
 
@@ -927,7 +926,7 @@ mod tests {
         storage: &mut RedisStorage<Email>,
         worker_id: &WorkerId,
     ) -> Request<Email> {
-        let mut stream = storage.fetch_next(worker_id);
+        let stream = storage.fetch_next(worker_id);
         stream
             .await
             .expect("stream is empty")

--- a/packages/apalis-sql/src/context.rs
+++ b/packages/apalis-sql/src/context.rs
@@ -6,7 +6,7 @@ use sqlx::types::chrono::{DateTime, Utc};
 use std::{fmt, str::FromStr};
 
 /// The context for a job is represented here
-/// Used to provide a context when a job is defined through the [Job] trait
+/// Used to provide a context for a job with an sql backend
 #[derive(Debug, Clone)]
 pub struct SqlContext {
     id: TaskId,
@@ -127,7 +127,7 @@ impl SqlContext {
     }
 }
 
-/// Represents the state of a [Request]
+/// Represents the state of a job
 #[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, std::cmp::Eq)]
 pub enum State {
     /// Job is pending

--- a/packages/apalis-sql/src/lib.rs
+++ b/packages/apalis-sql/src/lib.rs
@@ -58,7 +58,7 @@ impl Config {
     pub fn new(namespace: &str) -> Self {
         Config::default().namespace(namespace)
     }
-    
+
     /// Interval between database poll queries
     ///
     /// Defaults to 30ms

--- a/packages/apalis-sql/src/lib.rs
+++ b/packages/apalis-sql/src/lib.rs
@@ -54,6 +54,11 @@ impl Default for Config {
 }
 
 impl Config {
+    /// Create a new config with a jobs namespace
+    pub fn new(namespace: &str) -> Self {
+        Config::default().namespace(namespace)
+    }
+    
     /// Interval between database poll queries
     ///
     /// Defaults to 30ms

--- a/packages/apalis-sql/src/mysql.rs
+++ b/packages/apalis-sql/src/mysql.rs
@@ -19,6 +19,7 @@ use serde_json::Value;
 use sqlx::mysql::MySqlRow;
 use sqlx::types::chrono::{DateTime, Utc};
 use sqlx::{MySql, Pool, Row};
+use std::any::type_name;
 use std::convert::TryInto;
 use std::sync::Arc;
 use std::{fmt, io};
@@ -89,7 +90,7 @@ impl MysqlStorage<()> {
 impl<T: Serialize + DeserializeOwned> MysqlStorage<T> {
     /// Create a new instance from a pool
     pub fn new(pool: MySqlPool) -> Self {
-        Self::new_with_config(pool, Config::default())
+        Self::new_with_config(pool, Config::new(type_name::<T>()))
     }
 
     /// Create a new instance from a pool and custom config
@@ -248,7 +249,7 @@ where
     }
 
     async fn fetch_by_id(
-        &self,
+        &mut self,
         job_id: &TaskId,
     ) -> Result<Option<Request<Self::Job>>, sqlx::Error> {
         let pool = self.pool.clone();
@@ -272,7 +273,7 @@ where
         }
     }
 
-    async fn len(&self) -> Result<i64, sqlx::Error> {
+    async fn len(&mut self) -> Result<i64, sqlx::Error> {
         let pool = self.pool.clone();
 
         let query = "Select Count(*) as count from jobs where status='Pending'";
@@ -303,7 +304,7 @@ where
         Ok(())
     }
 
-    async fn update(&self, job: Request<Self::Job>) -> Result<(), sqlx::Error> {
+    async fn update(&mut self, job: Request<Self::Job>) -> Result<(), sqlx::Error> {
         let pool = self.pool.clone();
         let ctx = job
             .get::<SqlContext>()
@@ -339,11 +340,11 @@ where
         Ok(())
     }
 
-    async fn is_empty(&self) -> Result<bool, Self::Error> {
+    async fn is_empty(&mut self) -> Result<bool, Self::Error> {
         Ok(self.len().await? == 0)
     }
 
-    async fn vacuum(&self) -> Result<usize, sqlx::Error> {
+    async fn vacuum(&mut self) -> Result<usize, sqlx::Error> {
         let pool = self.pool.clone();
         let query = "Delete from jobs where status='Done'";
         let record = sqlx::query(query).execute(&pool).await?;
@@ -358,11 +359,8 @@ impl<T: Serialize + DeserializeOwned + Sync + Send + Unpin + 'static> Backend<Re
 
     type Layer = AckLayer<MysqlStorage<T>, T>;
 
-    fn common_layer(&self, worker_id: WorkerId) -> Self::Layer {
-        AckLayer::new(self.clone(), worker_id)
-    }
-
-    fn poll(self, worker: WorkerId) -> Poller<Self::Stream> {
+    fn poll(self, worker: WorkerId) -> Poller<Self::Stream, Self::Layer> {
+        let layer = AckLayer::new(self.clone(), worker.clone());
         let config = self.config.clone();
         let controller = self.controller.clone();
         let pool = self.pool.clone();
@@ -409,17 +407,21 @@ impl<T: Serialize + DeserializeOwned + Sync + Send + Unpin + 'static> Backend<Re
                 apalis_core::sleep(config.keep_alive).await;
             }
         };
-        Poller::new(stream, async {
-            futures::join!(heartbeat, ack_heartbeat);
-        })
+        Poller::new_with_layer(
+            stream,
+            async {
+                futures::join!(heartbeat, ack_heartbeat);
+            },
+            layer,
+        )
     }
 }
 
-impl<T: Sync> Ack<T> for MysqlStorage<T> {
+impl<T: Sync + Send> Ack<T> for MysqlStorage<T> {
     type Acknowledger = TaskId;
     type Error = sqlx::Error;
     async fn ack(
-        &self,
+        &mut self,
         worker_id: &WorkerId,
         task_id: &Self::Acknowledger,
     ) -> Result<(), sqlx::Error> {

--- a/packages/apalis-sql/src/postgres.rs
+++ b/packages/apalis-sql/src/postgres.rs
@@ -548,7 +548,7 @@ impl<T> PostgresStorage<T> {
     }
 
     /// Puts the job instantly back into the queue
-    /// Another [Worker] may consume
+    /// Another Worker may consume
     pub async fn retry(
         &mut self,
         worker_id: &WorkerId,
@@ -642,13 +642,8 @@ mod tests {
         storage: &mut PostgresStorage<Email>,
         worker_id: &WorkerId,
     ) -> Request<Email> {
-        let mut stream = storage.stream_jobs(worker_id, std::time::Duration::from_secs(10), 1);
-        stream
-            .next()
-            .await
-            .expect("stream is empty")
-            .expect("failed to poll job")
-            .expect("no job is pending")
+        let mut req = storage.fetch_next(worker_id).await;
+        req.unwrap()[0].clone()
     }
 
     async fn register_worker_at(

--- a/packages/apalis-sql/src/postgres.rs
+++ b/packages/apalis-sql/src/postgres.rs
@@ -53,14 +53,15 @@ use apalis_core::task::namespace::Namespace;
 use apalis_core::task::task_id::TaskId;
 use apalis_core::worker::WorkerId;
 use apalis_core::{Backend, Codec};
-use async_stream::try_stream;
-use futures::{FutureExt, Stream};
-use futures::{StreamExt, TryStreamExt};
+use futures::channel::mpsc;
+use futures::StreamExt;
+use futures::{select, stream, SinkExt};
 use log::error;
 use serde::{de::DeserializeOwned, Serialize};
 use sqlx::postgres::PgListener;
 use sqlx::types::chrono::{DateTime, Utc};
 use sqlx::{Pool, Postgres, Row};
+use std::any::type_name;
 use std::convert::TryInto;
 use std::sync::Arc;
 use std::{fmt, io};
@@ -88,6 +89,7 @@ pub struct PostgresStorage<T> {
     config: Config,
     controller: Controller,
     ack_notify: Notify<(WorkerId, TaskId)>,
+    subscription: Option<PgSubscription>,
 }
 
 impl<T> Clone for PostgresStorage<T> {
@@ -99,6 +101,7 @@ impl<T> Clone for PostgresStorage<T> {
             config: self.config.clone(),
             controller: self.controller.clone(),
             ack_notify: self.ack_notify.clone(),
+            subscription: self.subscription.clone(),
         }
     }
 }
@@ -126,55 +129,77 @@ impl<T: Serialize + DeserializeOwned + Sync + Send + Unpin + 'static> Backend<Re
 
     type Layer = AckLayer<PostgresStorage<T>, T>;
 
-    fn common_layer(&self, worker_id: WorkerId) -> Self::Layer {
-        AckLayer::new(self.clone(), worker_id)
-    }
-
-    fn poll(mut self, worker: WorkerId) -> Poller<Self::Stream> {
+    fn poll(mut self, worker: WorkerId) -> Poller<Self::Stream, Self::Layer> {
+        let layer = AckLayer::new(self.clone(), worker.clone());
+        let subscription = self.subscription.clone();
         let config = self.config.clone();
         let controller = self.controller.clone();
-        let stream = self
-            .stream_jobs(&worker, config.poll_interval, config.buffer_size)
-            .map_err(|e| Error::SourceError(Box::new(e)));
-        let stream = BackendStream::new(stream.boxed(), controller);
+        let (mut tx, rx) = mpsc::channel(self.config.buffer_size);
         let ack_notify = self.ack_notify.clone();
         let pool = self.pool.clone();
-        let ack_heartbeat = async move {
-            while let Some(ids) = ack_notify
-                .clone()
-                .ready_chunks(config.buffer_size)
-                .next()
-                .await
-            {
-                let worker_ids: Vec<String> = ids.iter().map(|c| c.0.to_string()).collect();
-                let task_ids: Vec<String> = ids.iter().map(|c| c.1.to_string()).collect();
 
-                let query =
-            "UPDATE apalis.jobs SET status = 'Done', done_at = now() WHERE id = ANY($1::text[]) AND lock_by = ANY($2::text[])";
-                if let Err(e) = sqlx::query(query)
-                    .bind(task_ids)
-                    .bind(worker_ids)
-                    .execute(&pool)
-                    .await
-                {
-                    error!("Ack failed: {e}");
+        let heartbeat = async move {
+            let mut keep_alive_stm = apalis_core::interval::interval(config.keep_alive).fuse();
+            let mut ack_stream = ack_notify.clone().ready_chunks(config.buffer_size).fuse();
+
+            let mut poll_next_stm = apalis_core::interval::interval(config.poll_interval).fuse();
+
+            let mut pg_notification = subscription
+                .map(|stm| stm.notify.boxed().fuse())
+                .unwrap_or(stream::iter(vec![]).boxed().fuse());
+
+            async fn fetch_next_batch<T: Unpin + DeserializeOwned + Send + 'static>(
+                storage: &mut PostgresStorage<T>,
+                worker: &WorkerId,
+                tx: &mut mpsc::Sender<Result<Option<Request<T>>, Error>>,
+            ) {
+                let res = storage.fetch_next(worker).await.unwrap();
+                for job in res {
+                    tx.send(Ok(Some(job))).await.unwrap();
                 }
-                apalis_core::sleep(config.poll_interval).await;
+            }
+
+            loop {
+                select! {
+                    _ = keep_alive_stm.next() => {
+                        let now: i64 = Utc::now().timestamp();
+                        self.keep_alive_at::<Self::Layer>(&worker, now).await.unwrap();
+                    }
+                    ids = ack_stream.next() => {
+                        if let Some(ids) = ids {
+                            let worker_ids: Vec<String> = ids.iter().map(|c| c.0.to_string()).collect();
+                            let task_ids: Vec<String> = ids.iter().map(|c| c.1.to_string()).collect();
+
+                            let query =
+                        "UPDATE apalis.jobs SET status = 'Done', done_at = now() WHERE id = ANY($1::text[]) AND lock_by = ANY($2::text[])";
+                            if let Err(e) = sqlx::query(query)
+                                .bind(task_ids)
+                                .bind(worker_ids)
+                                .execute(&pool)
+                                .await
+                            {
+                                error!("Ack failed: {e}");
+                            }
+                        }
+                    }
+                    _ = poll_next_stm.next() => {
+                        fetch_next_batch(&mut self, &worker, &mut tx).await;
+                    }
+                    _ = pg_notification.next() => {
+                        fetch_next_batch(&mut self, &worker, &mut tx).await;
+                    }
+
+
+                };
             }
         };
-        let heartbeat = async move {
-            loop {
-                let now: i64 = Utc::now().timestamp();
-                if let Err(e) = self.keep_alive_at::<Self::Layer>(&worker, now).await {
-                    error!("Heartbeat failed: {e}")
-                }
-                apalis_core::sleep(config.keep_alive).await;
-            }
-        }
-        .boxed();
-        Poller::new(stream, async {
-            futures::join!(heartbeat, ack_heartbeat);
-        })
+        Poller::new_with_layer(
+            BackendStream::new(rx.boxed(), controller),
+            async {
+                futures::join!(heartbeat);
+            },
+            layer,
+        )
     }
 }
 
@@ -196,7 +221,7 @@ impl PostgresStorage<()> {
 impl<T: Serialize + DeserializeOwned> PostgresStorage<T> {
     /// New Storage from [PgPool]
     pub fn new(pool: PgPool) -> Self {
-        Self::new_with_config(pool, Config::default())
+        Self::new_with_config(pool, Config::new(type_name::<T>()))
     }
     /// New Storage from [PgPool] and custom config
     pub fn new_with_config(pool: PgPool, config: Config) -> Self {
@@ -207,6 +232,7 @@ impl<T: Serialize + DeserializeOwned> PostgresStorage<T> {
             config,
             controller: Controller::new(),
             ack_notify: Notify::new(),
+            subscription: None,
         }
     }
 
@@ -241,6 +267,16 @@ impl PgListen {
         })
     }
 
+    /// Add a new subscription with a storage
+    pub fn subscribe_with<T>(&mut self, storage: &mut PostgresStorage<T>) {
+        let sub = PgSubscription {
+            notify: Notify::new(),
+        };
+        self.subscriptions
+            .push((storage.config.namespace.to_owned(), sub.clone()));
+        storage.subscription = Some(sub)
+    }
+
     /// Add a new subscription
     pub fn subscribe(&mut self, namespace: &str) -> PgSubscription {
         let sub = PgSubscription {
@@ -266,44 +302,37 @@ impl PgListen {
 }
 
 impl<T: DeserializeOwned + Send + Unpin + 'static> PostgresStorage<T> {
-    fn stream_jobs(
-        &self,
-        worker_id: &WorkerId,
-        interval: Duration,
-        buffer_size: usize,
-    ) -> impl Stream<Item = Result<Option<Request<T>>, sqlx::Error>> {
-        let pool = self.pool.clone();
-        let worker_id = worker_id.clone();
-        let codec = self.codec.clone();
-        let config = self.config.clone();
-        try_stream! {
-            loop {
-                //  Ideally wait for a job or a tick
-                apalis_core::sleep(interval).await;
-                let tx = pool.clone();
-                let job_type = &config.namespace;
-                let fetch_query = "Select * from apalis.get_jobs($1, $2, $3);";
-                let jobs: Vec<SqlRequest<serde_json::Value>> = sqlx::query_as(fetch_query)
-                    .bind(worker_id.to_string())
-                    .bind(job_type)
-                    // https://docs.rs/sqlx/latest/sqlx/postgres/types/index.html
-                    .bind(i32::try_from(buffer_size).map_err(|e| sqlx::Error::Io(io::Error::new(io::ErrorKind::InvalidInput, e)))?)
-                    .fetch_all(&tx)
-                    .await?;
-                for job in jobs {
-
-                    yield Some(Into::into(SqlRequest {
-                        context: job.context,
-                        req: codec.decode(&job.req).map_err(|e| sqlx::Error::Io(io::Error::new(io::ErrorKind::InvalidData, e)))?,
-                    })).map(|mut req: Request<T>| {
-                        req.insert(Namespace(config.namespace.clone()));
-                        req
-                    })
-                }
-
-            }
-        }
-        .boxed()
+    async fn fetch_next(&mut self, worker_id: &WorkerId) -> Result<Vec<Request<T>>, sqlx::Error> {
+        let config = &self.config;
+        let codec = &self.codec;
+        let job_type = &config.namespace;
+        let fetch_query = "Select * from apalis.get_jobs($1, $2, $3);";
+        let jobs: Vec<SqlRequest<serde_json::Value>> = sqlx::query_as(fetch_query)
+            .bind(worker_id.to_string())
+            .bind(job_type)
+            // https://docs.rs/sqlx/latest/sqlx/postgres/types/index.html
+            .bind(
+                i32::try_from(config.buffer_size)
+                    .map_err(|e| sqlx::Error::Io(io::Error::new(io::ErrorKind::InvalidInput, e)))?,
+            )
+            .fetch_all(&self.pool)
+            .await?;
+        let jobs: Vec<_> = jobs
+            .into_iter()
+            .map(|job| {
+                let req = SqlRequest {
+                    context: job.context,
+                    req: codec
+                        .decode(&job.req)
+                        .map_err(|e| sqlx::Error::Io(io::Error::new(io::ErrorKind::InvalidData, e)))
+                        .unwrap(),
+                };
+                let mut req: Request<T> = req.into();
+                req.insert(Namespace(config.namespace.clone()));
+                req
+            })
+            .collect();
+        Ok(jobs)
     }
 
     async fn keep_alive_at<Service>(
@@ -311,7 +340,6 @@ impl<T: DeserializeOwned + Send + Unpin + 'static> PostgresStorage<T> {
         worker_id: &WorkerId,
         last_seen: Timestamp,
     ) -> Result<(), sqlx::Error> {
-        let pool = self.pool.clone();
         let last_seen = DateTime::from_timestamp(last_seen, 0).ok_or(sqlx::Error::Io(
             io::Error::new(io::ErrorKind::InvalidInput, "Invalid Timestamp"),
         ))?;
@@ -327,7 +355,7 @@ impl<T: DeserializeOwned + Send + Unpin + 'static> PostgresStorage<T> {
             .bind(storage_name)
             .bind(std::any::type_name::<Service>())
             .bind(last_seen)
-            .execute(&pool)
+            .execute(&self.pool)
             .await?;
         Ok(())
     }
@@ -353,7 +381,7 @@ where
     async fn push(&mut self, job: Self::Job) -> Result<TaskId, sqlx::Error> {
         let id = TaskId::new();
         let query = "INSERT INTO apalis.jobs VALUES ($1, $2, $3, 'Pending', 0, 25, NOW() , NULL, NULL, NULL, NULL)";
-        let pool = self.pool.clone();
+
         let job = self
             .codec
             .encode(&job)
@@ -363,7 +391,7 @@ where
             .bind(job)
             .bind(id.to_string())
             .bind(&job_type)
-            .execute(&pool)
+            .execute(&self.pool)
             .await?;
         Ok(id)
     }
@@ -371,7 +399,7 @@ where
     async fn schedule(&mut self, job: Self::Job, on: Timestamp) -> Result<TaskId, sqlx::Error> {
         let query =
             "INSERT INTO apalis.jobs VALUES ($1, $2, $3, 'Pending', 0, 25, $4, NULL, NULL, NULL, NULL)";
-        let pool = self.pool.clone();
+
         let id = TaskId::new();
         let on = DateTime::from_timestamp(on, 0);
         let job = self
@@ -384,21 +412,19 @@ where
             .bind(id.to_string())
             .bind(job_type)
             .bind(on)
-            .execute(&pool)
+            .execute(&self.pool)
             .await?;
         Ok(id)
     }
 
     async fn fetch_by_id(
-        &self,
+        &mut self,
         job_id: &TaskId,
     ) -> Result<Option<Request<Self::Job>>, sqlx::Error> {
-        let pool = self.pool.clone();
-
         let fetch_query = "SELECT * FROM apalis.jobs WHERE id = $1";
         let res: Option<SqlRequest<serde_json::Value>> = sqlx::query_as(fetch_query)
             .bind(job_id.to_string())
-            .fetch_optional(&pool)
+            .fetch_optional(&self.pool)
             .await?;
         match res {
             None => Ok(None),
@@ -414,15 +440,13 @@ where
         }
     }
 
-    async fn len(&self) -> Result<i64, sqlx::Error> {
-        let pool = self.pool.clone();
+    async fn len(&mut self) -> Result<i64, sqlx::Error> {
         let query = "Select Count(*) as count from apalis.jobs where status='Pending'";
-        let record = sqlx::query(query).fetch_one(&pool).await?;
+        let record = sqlx::query(query).fetch_one(&self.pool).await?;
         record.try_get("count")
     }
 
     async fn reschedule(&mut self, job: Request<T>, wait: Duration) -> Result<(), sqlx::Error> {
-        let pool = self.pool.clone();
         let ctx = job
             .get::<SqlContext>()
             .ok_or(sqlx::Error::Io(io::Error::new(
@@ -431,7 +455,7 @@ where
             )))?;
         let job_id = ctx.id();
         let on = Utc::now() + wait;
-        let mut tx = pool.acquire().await?;
+        let mut tx = self.pool.acquire().await?;
         let query =
                 "UPDATE apalis.jobs SET status = 'Pending', done_at = NULL, lock_by = NULL, lock_at = NULL, run_at = $2 WHERE id = $1";
 
@@ -443,8 +467,7 @@ where
         Ok(())
     }
 
-    async fn update(&self, job: Request<Self::Job>) -> Result<(), sqlx::Error> {
-        let pool = self.pool.clone();
+    async fn update(&mut self, job: Request<Self::Job>) -> Result<(), sqlx::Error> {
         let ctx = job
             .get::<SqlContext>()
             .ok_or(sqlx::Error::Io(io::Error::new(
@@ -463,7 +486,7 @@ where
         let lock_at = *ctx.lock_at();
         let last_error = ctx.last_error().clone();
 
-        let mut tx = pool.acquire().await?;
+        let mut tx = self.pool.acquire().await?;
         let query =
                 "UPDATE apalis.jobs SET status = $1, attempts = $2, done_at = $3, lock_by = $4, lock_at = $5, last_error = $6 WHERE id = $7";
         sqlx::query(query)
@@ -479,23 +502,22 @@ where
         Ok(())
     }
 
-    async fn is_empty(&self) -> Result<bool, sqlx::Error> {
+    async fn is_empty(&mut self) -> Result<bool, sqlx::Error> {
         Ok(self.len().await? == 0)
     }
 
-    async fn vacuum(&self) -> Result<usize, sqlx::Error> {
-        let pool = self.pool.clone();
+    async fn vacuum(&mut self) -> Result<usize, sqlx::Error> {
         let query = "Delete from apalis.jobs where status='Done'";
-        let record = sqlx::query(query).execute(&pool).await?;
+        let record = sqlx::query(query).execute(&self.pool).await?;
         Ok(record.rows_affected().try_into().unwrap_or_default())
     }
 }
 
-impl<T: Sync> Ack<T> for PostgresStorage<T> {
+impl<T: Sync + Send> Ack<T> for PostgresStorage<T> {
     type Acknowledger = TaskId;
     type Error = sqlx::Error;
     async fn ack(
-        &self,
+        &mut self,
         worker_id: &WorkerId,
         task_id: &Self::Acknowledger,
     ) -> Result<(), sqlx::Error> {
@@ -514,9 +536,7 @@ impl<T> PostgresStorage<T> {
         worker_id: &WorkerId,
         task_id: &TaskId,
     ) -> Result<(), sqlx::Error> {
-        let pool = self.pool.clone();
-
-        let mut tx = pool.acquire().await?;
+        let mut tx = self.pool.acquire().await?;
         let query =
                 "UPDATE apalis.jobs SET status = 'Killed', done_at = now() WHERE id = $1 AND lock_by = $2";
         sqlx::query(query)
@@ -534,9 +554,7 @@ impl<T> PostgresStorage<T> {
         worker_id: &WorkerId,
         task_id: &TaskId,
     ) -> Result<(), sqlx::Error> {
-        let pool = self.pool.clone();
-
-        let mut tx = pool.acquire().await?;
+        let mut tx = self.pool.acquire().await?;
         let query =
                 "UPDATE apalis.jobs SET status = 'Pending', done_at = NULL, lock_by = NULL WHERE id = $1 AND lock_by = $2";
         sqlx::query(query)
@@ -548,7 +566,7 @@ impl<T> PostgresStorage<T> {
     }
 
     /// Reenqueue jobs that have been abandoned by their workers
-    pub async fn reenqueue_orphaned(&self, count: i32) -> Result<(), sqlx::Error> {
+    pub async fn reenqueue_orphaned(&mut self, count: i32) -> Result<(), sqlx::Error> {
         let job_type = self.config.namespace.clone();
         let mut tx = self.pool.acquire().await?;
         let query = "Update apalis.jobs

--- a/packages/apalis-sql/src/sqlite.rs
+++ b/packages/apalis-sql/src/sqlite.rs
@@ -371,7 +371,7 @@ where
 
 impl<T> SqliteStorage<T> {
     /// Puts the job instantly back into the queue
-    /// Another [Worker] may consume
+    /// Another Worker may consume
     pub async fn retry(
         &mut self,
         worker_id: &WorkerId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 //! async fn main() {
 //!     let redis = std::env::var("REDIS_URL").expect("Missing REDIS_URL env variable");
 //!     let conn = apalis::redis::connect(redis).await.unwrap();
-//!     let storage = RedisStorage::new(conn, Config::default());
+//!     let storage = RedisStorage::new(conn);
 //!     Monitor::<TokioExecutor>::new()
 //!         .register_with_count(2, {
 //!             WorkerBuilder::new(&format!("quick-sand"))


### PR DESCRIPTION

Changelog:
- Redis storage doesnt require pool to be clone. Allows use of deadpool-redis among others.
- Namespace is picked by default for `new` methods.