### PR TITLE
Update sqlx to 0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ redis = { version = "0.25.3", default-features = false, features = [
 ] }
 
 [dev-dependencies.sqlx]
-version = "0.7.4"
+version = "0.8.1"
 default-features = false
 features = ["chrono", "mysql", "sqlite", "postgres"]
 

--- a/examples/sqlite/Cargo.toml
+++ b/examples/sqlite/Cargo.toml
@@ -25,6 +25,6 @@ default-features = false
 version = "0.1"
 
 [dependencies.sqlx]
-version = "0.7.0"
+version = "0.8.1"
 default-features = false
 features = ["sqlite"]

--- a/packages/apalis-sql/Cargo.toml
+++ b/packages/apalis-sql/Cargo.toml
@@ -19,7 +19,7 @@ async-std-comp = ["async-std", "sqlx/runtime-async-std-rustls"]
 tokio-comp = ["tokio", "sqlx/runtime-tokio-rustls"]
 
 [dependencies.sqlx]
-version = "0.7.4"
+version = "0.8.1"
 default-features = false
 features = ["chrono"]
 


### PR DESCRIPTION
Updates the `sqlx` dependency to `0.8.1` to address the vulnerability described in #401 