### PR TITLE
[mysql] prevent cascading deletes on jobs by `keep_alive_at`

### DIFF
--- a/packages/apalis-sql/src/mysql.rs
+++ b/packages/apalis-sql/src/mysql.rs
@@ -177,13 +177,14 @@ impl<T: DeserializeOwned + Send + Unpin + Job + Sync + 'static> MysqlStorage<T> 
         let worker_type = T::NAME;
         let storage_name = std::any::type_name::<Self>();
         let query =
-            "REPLACE INTO workers (id, worker_type, storage_name, layers, last_seen) VALUES (?, ?, ?, ?, ?);";
+            "INSERT INTO workers (id, worker_type, storage_name, layers, last_seen) VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE id = ?;";
         sqlx::query(query)
             .bind(worker_id.to_string())
             .bind(worker_type)
             .bind(storage_name)
             .bind(std::any::type_name::<Service>())
             .bind(last_seen)
+            .bind(worker_id.to_string())
             .execute(&mut *tx)
             .await?;
         Ok(())


### PR DESCRIPTION
`keep_alive_at` function uses replace to update the worker row and that forces the jobs child rows to be deleted due to their foreign key relationship. This behavior is due MySQL `REPLACE` deletes first a row when duplicated.

Using `INSERT .. ON DUPLICATE KEY` solves the issue. Jobs are not deleted anymore when the `keep_alive_at` runs. Users should be responsible about truncating the jobs table with this approach. Fixes  #48 

 