### PR TITLE
[sql]: Make config accessible for sql package

### DIFF
--- a/packages/apalis-sql/src/mysql.rs
+++ b/packages/apalis-sql/src/mysql.rs
@@ -25,7 +25,7 @@ use std::{marker::PhantomData, ops::Add, time::Duration};
 
 use crate::context::SqlContext;
 use crate::from_row::SqlRequest;
-use crate::Config;
+pub use crate::Config;
 
 pub use sqlx::mysql::MySqlPool;
 

--- a/packages/apalis-sql/src/mysql.rs
+++ b/packages/apalis-sql/src/mysql.rs
@@ -177,13 +177,14 @@ impl<T: DeserializeOwned + Send + Unpin + Job + Sync + 'static> MysqlStorage<T> 
         let worker_type = T::NAME;
         let storage_name = std::any::type_name::<Self>();
         let query =
-            "REPLACE INTO workers (id, worker_type, storage_name, layers, last_seen) VALUES (?, ?, ?, ?, ?);";
+            "INSERT INTO workers (id, worker_type, storage_name, layers, last_seen) VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE id = ?;";
         sqlx::query(query)
             .bind(worker_id.to_string())
             .bind(worker_type)
             .bind(storage_name)
             .bind(std::any::type_name::<Service>())
             .bind(last_seen)
+            .bind(worker_id.to_string())
             .execute(&mut *tx)
             .await?;
         Ok(())


### PR DESCRIPTION
Minimal change to be able to configure sql (mysql at least) storages with new_with_config()