### PR TITLE
chore: bump to 0.6.0-rc.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ repository = "https://github.com/geofmureithi/apalis"
 
 [package]
 name = "apalis"
-version = "0.6.0-rc.7"
+version = "0.6.0-rc.8"
 authors = ["Geoffrey Mureithi <mureithinjuguna@gmail.com>"]
 description = "Simple, extensible multithreaded background job processing for Rust"
 edition.workspace = true
@@ -58,7 +58,7 @@ layers = [
 docsrs = ["document-features"]
 
 [dependencies.apalis-core]
-version = "0.6.0-rc.7"
+version = "0.6.0-rc.8"
 default-features = false
 path = "./packages/apalis-core"
 

--- a/packages/apalis-core/Cargo.toml
+++ b/packages/apalis-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apalis-core"
-version = "0.6.0-rc.7"
+version = "0.6.0-rc.8"
 authors = ["Njuguna Mureithi <mureithinjuguna@gmail.com>"]
 edition.workspace = true
 repository.workspace = true

--- a/packages/apalis-cron/Cargo.toml
+++ b/packages/apalis-cron/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apalis-cron"
-version = "0.6.0-rc.7"
+version = "0.6.0-rc.8"
 edition.workspace = true
 repository.workspace = true
 authors = ["Njuguna Mureithi <mureithinjuguna@gmail.com>"]
@@ -10,7 +10,7 @@ description = "A simple yet extensible library for cron-like job scheduling for 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-apalis-core = { path = "../../packages/apalis-core", version = "0.6.0-rc.7", default-features = false, features = [
+apalis-core = { path = "../../packages/apalis-core", version = "0.6.0-rc.8", default-features = false, features = [
     "sleep",
 ] }
 cron = "0.12.1"

--- a/packages/apalis-redis/Cargo.toml
+++ b/packages/apalis-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apalis-redis"
-version = "0.6.0-rc.7"
+version = "0.6.0-rc.8"
 authors = ["Njuguna Mureithi <mureithinjuguna@gmail.com>"]
 edition.workspace = true
 repository.workspace = true
@@ -12,7 +12,7 @@ description = "Redis Storage for apalis: use Redis for background jobs and messa
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-apalis-core = { path = "../../packages/apalis-core", version = "0.6.0-rc.7", default-features = false, features = [
+apalis-core = { path = "../../packages/apalis-core", version = "0.6.0-rc.8", default-features = false, features = [
     "sleep",
     "json",
 ] }

--- a/packages/apalis-sql/Cargo.toml
+++ b/packages/apalis-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apalis-sql"
-version = "0.6.0-rc.7"
+version = "0.6.0-rc.8"
 authors = ["Njuguna Mureithi <mureithinjuguna@gmail.com>"]
 edition.workspace = true
 repository.workspace = true
@@ -26,7 +26,7 @@ features = ["chrono"]
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-apalis-core = { path = "../../packages/apalis-core", version = "0.6.0-rc.7", default-features = false, features = [
+apalis-core = { path = "../../packages/apalis-core", version = "0.6.0-rc.8", default-features = false, features = [
     "sleep",
     "json",
 ] }


### PR DESCRIPTION
- This includes vital fixes and anyone using rc.7 should update