### PR TITLE
fix: target done jobs with vacuuming instead of dead jobs

### DIFF
--- a/packages/apalis-redis/src/storage.rs
+++ b/packages/apalis-redis/src/storage.rs
@@ -599,7 +599,7 @@ where
         let mut conn = self.conn.clone();
 
         vacuum_script
-            .key(self.queue.dead_jobs_set.clone())
+            .key(self.queue.done_jobs_set.clone())
             .key(self.queue.job_data_hash.clone())
             .invoke_async(&mut conn)
             .await


### PR DESCRIPTION
It seems that the initial intention was to clean up done jobs (from the surrounding code also), but the code references dead jobs. It also might make more sense to drop done jobs and keep dead ones for issue analysis.

SQL packages remove "done" jobs with vacuuming also:
```SQL
Delete from jobs where status='Done'
```