### PR TITLE
fix: apply max_attempts set via SqlContext

### DIFF
--- a/packages/apalis-sql/src/context.rs
+++ b/packages/apalis-sql/src/context.rs
@@ -8,7 +8,7 @@ use std::{fmt, str::FromStr};
 
 /// The context for a job is represented here
 /// Used to provide a context for a job with an sql backend
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SqlContext {
     status: State,
     run_at: DateTime<Utc>,
@@ -17,6 +17,12 @@ pub struct SqlContext {
     lock_at: Option<i64>,
     lock_by: Option<WorkerId>,
     done_at: Option<i64>,
+}
+
+impl Default for SqlContext {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl SqlContext {

--- a/packages/apalis-sql/src/from_row.rs
+++ b/packages/apalis-sql/src/from_row.rs
@@ -77,8 +77,9 @@ impl<'r, T: Decode<'r, sqlx::Sqlite> + Type<sqlx::Sqlite>>
         let run_at: i64 = row.try_get("run_at")?;
         context.set_run_at(DateTime::from_timestamp(run_at, 0).unwrap_or_default());
 
-        let max_attempts = row.try_get("max_attempts").unwrap_or(25);
-        context.set_max_attempts(max_attempts);
+        if let Ok(max_attempts) = row.try_get("max_attempts") {
+            context.set_max_attempts(max_attempts)
+        }
 
         let done_at: Option<i64> = row.try_get("done_at").unwrap_or_default();
         context.set_done_at(done_at);
@@ -139,8 +140,9 @@ impl<'r, T: Decode<'r, sqlx::Postgres> + Type<sqlx::Postgres>>
         let run_at = row.try_get("run_at")?;
         context.set_run_at(run_at);
 
-        let max_attempts = row.try_get("max_attempts").unwrap_or(25);
-        context.set_max_attempts(max_attempts);
+        if let Ok(max_attempts) = row.try_get("max_attempts") {
+            context.set_max_attempts(max_attempts)
+        }
 
         let done_at: Option<chrono::DateTime<Utc>> = row.try_get("done_at").unwrap_or_default();
         context.set_done_at(done_at.map(|d| d.timestamp()));
@@ -200,8 +202,9 @@ impl<'r, T: Decode<'r, sqlx::MySql> + Type<sqlx::MySql>> sqlx::FromRow<'r, sqlx:
         let run_at = row.try_get("run_at")?;
         context.set_run_at(run_at);
 
-        let max_attempts = row.try_get("max_attempts").unwrap_or(25);
-        context.set_max_attempts(max_attempts);
+        if let Ok(max_attempts) = row.try_get("max_attempts") {
+            context.set_max_attempts(max_attempts)
+        }
 
         let done_at: Option<chrono::NaiveDateTime> = row.try_get("done_at").unwrap_or_default();
         context.set_done_at(done_at.map(|d| d.and_utc().timestamp()));

--- a/packages/apalis-sql/src/mysql.rs
+++ b/packages/apalis-sql/src/mysql.rs
@@ -233,7 +233,7 @@ where
     ) -> Result<Parts<SqlContext>, sqlx::Error> {
         let (args, parts) = job.take_parts();
         let query =
-            "INSERT INTO jobs VALUES (?, ?, ?, 'Pending', 0, 25, now(), NULL, NULL, NULL, NULL)";
+            "INSERT INTO jobs VALUES (?, ?, ?, 'Pending', 0, ?, now(), NULL, NULL, NULL, NULL)";
         let pool = self.pool.clone();
 
         let job = C::encode(args)
@@ -243,6 +243,7 @@ where
             .bind(job)
             .bind(parts.task_id.to_string())
             .bind(job_type.to_string())
+            .bind(parts.context.max_attempts())
             .execute(&pool)
             .await?;
         Ok(parts)
@@ -253,8 +254,7 @@ where
         req: Request<Self::Job, SqlContext>,
         on: i64,
     ) -> Result<Parts<Self::Context>, sqlx::Error> {
-        let query =
-            "INSERT INTO jobs VALUES (?, ?, ?, 'Pending', 0, 25, ?, NULL, NULL, NULL, NULL)";
+        let query = "INSERT INTO jobs VALUES (?, ?, ?, 'Pending', 0, ?, ?, NULL, NULL, NULL, NULL)";
         let pool = self.pool.clone();
 
         let args = C::encode(&req.args)
@@ -265,6 +265,7 @@ where
             .bind(args)
             .bind(req.parts.task_id.to_string())
             .bind(job_type)
+            .bind(req.parts.context.max_attempts())
             .bind(on)
             .execute(&pool)
             .await?;


### PR DESCRIPTION
So that a custom number of attempts can be configured:

```rust
let mut ctx = SqlContext::new();
ctx.set_max_attempts(2);
let req = Request::new_with_ctx(job, ctx);
storage.push_request(req).await.unwrap();
```

While the default is still to try up to 25 times:

```rust
storage.push(job).await.unwrap();
```

Right now, the default will be used, no matter what the request contains.