### PR TITLE
feat: re-export sqlx

### DIFF
--- a/packages/apalis-sql/src/lib.rs
+++ b/packages/apalis-sql/src/lib.rs
@@ -36,6 +36,9 @@ pub mod sqlite;
 #[cfg_attr(docsrs, doc(cfg(feature = "mysql")))]
 pub mod mysql;
 
+// Re-exports
+pub use sqlx;
+
 /// Config for sql storages
 #[derive(Debug, Clone)]
 pub struct Config {


### PR DESCRIPTION
Making sqlx accessible to users of apalis without requiring them to explicitly add it as a dependency.

One of my use cases is a custom vacuum implementation that runs SQL using the already accessible `SqlitePool`.