### PR TITLE
feat: allow backends to emit errors

### DIFF
--- a/examples/redis-mq-example/src/main.rs
+++ b/examples/redis-mq-example/src/main.rs
@@ -56,7 +56,7 @@ where
 
     type Layer = AckLayer<Self, Req, RedisMqContext, Res>;
 
-    fn poll<Svc>(mut self, _worker_id: WorkerId) -> Poller<Self::Stream, Self::Layer> {
+    fn poll<Svc>(mut self, _worker_id: Worker<Context>) -> Poller<Self::Stream, Self::Layer> {
         let (mut tx, rx) = mpsc::channel(self.config.get_buffer_size());
         let stream: RequestStream<Request<Req, RedisMqContext>> = Box::pin(rx);
         let layer = AckLayer::new(self.clone());

--- a/examples/redis-mq-example/src/main.rs
+++ b/examples/redis-mq-example/src/main.rs
@@ -56,7 +56,7 @@ where
 
     type Layer = AckLayer<Self, Req, RedisMqContext, Res>;
 
-    fn poll<Svc>(mut self, _worker_id: Worker<Context>) -> Poller<Self::Stream, Self::Layer> {
+    fn poll<Svc>(mut self, _worker: &Worker<Context>) -> Poller<Self::Stream, Self::Layer> {
         let (mut tx, rx) = mpsc::channel(self.config.get_buffer_size());
         let stream: RequestStream<Request<Req, RedisMqContext>> = Box::pin(rx);
         let layer = AckLayer::new(self.clone());

--- a/packages/apalis-core/src/lib.rs
+++ b/packages/apalis-core/src/lib.rs
@@ -81,7 +81,7 @@ pub trait Backend<Req, Res> {
     /// Returns a poller that is ready for streaming
     fn poll<Svc: Service<Req, Response = Res>>(
         self,
-        worker: Worker<Context>,
+        worker: &Worker<Context>,
     ) -> Poller<Self::Stream, Self::Layer>;
 }
 /// A codec allows backends to encode and decode data
@@ -266,7 +266,7 @@ pub mod test_utils {
             let worker_id = WorkerId::new("test-worker");
             let worker = Worker::new(worker_id, crate::worker::Context::default());
             let b = backend.clone();
-            let mut poller = b.poll::<S>(worker);
+            let mut poller = b.poll::<S>(&worker);
             let (stop_tx, mut stop_rx) = channel::<()>(1);
 
             let (mut res_tx, res_rx) = channel(10);

--- a/packages/apalis-core/src/lib.rs
+++ b/packages/apalis-core/src/lib.rs
@@ -27,7 +27,7 @@ use futures::Stream;
 use poller::Poller;
 use serde::{Deserialize, Serialize};
 use tower::Service;
-use worker::WorkerId;
+use worker::{Context, Worker};
 
 /// Represent utilities for creating worker instances.
 pub mod builder;
@@ -81,7 +81,7 @@ pub trait Backend<Req, Res> {
     /// Returns a poller that is ready for streaming
     fn poll<Svc: Service<Req, Response = Res>>(
         self,
-        worker: WorkerId,
+        worker: Worker<Context>,
     ) -> Poller<Self::Stream, Self::Layer>;
 }
 /// A codec allows backends to encode and decode data
@@ -165,7 +165,7 @@ pub mod test_utils {
     use crate::error::BoxDynError;
     use crate::request::Request;
     use crate::task::task_id::TaskId;
-    use crate::worker::WorkerId;
+    use crate::worker::{Worker, WorkerId};
     use crate::Backend;
     use futures::channel::mpsc::{channel, Receiver, Sender};
     use futures::future::BoxFuture;
@@ -264,8 +264,9 @@ pub mod test_utils {
             >>::Future: Send + 'static,
         {
             let worker_id = WorkerId::new("test-worker");
+            let worker = Worker::new(worker_id, crate::worker::Context::default());
             let b = backend.clone();
-            let mut poller = b.poll::<S>(worker_id);
+            let mut poller = b.poll::<S>(worker);
             let (stop_tx, mut stop_rx) = channel::<()>(1);
 
             let (mut res_tx, res_rx) = channel(10);

--- a/packages/apalis-core/src/memory.rs
+++ b/packages/apalis-core/src/memory.rs
@@ -101,7 +101,7 @@ impl<T: Send + 'static + Sync, Res> Backend<Request<T, ()>, Res> for MemoryStora
 
     type Layer = Identity;
 
-    fn poll<Svc>(self, _worker: Worker<worker::Context>) -> Poller<Self::Stream> {
+    fn poll<Svc>(self, _worker: &Worker<worker::Context>) -> Poller<Self::Stream> {
         let stream = self.inner.map(|r| Ok(Some(r))).boxed();
         Poller {
             stream: BackendStream::new(stream, self.controller),

--- a/packages/apalis-core/src/memory.rs
+++ b/packages/apalis-core/src/memory.rs
@@ -2,7 +2,7 @@ use crate::{
     mq::MessageQueue,
     poller::{controller::Controller, stream::BackendStream},
     request::{Request, RequestStream},
-    worker::WorkerId,
+    worker::{self, Worker},
     Backend, Poller,
 };
 use futures::{
@@ -101,7 +101,7 @@ impl<T: Send + 'static + Sync, Res> Backend<Request<T, ()>, Res> for MemoryStora
 
     type Layer = Identity;
 
-    fn poll<Svc>(self, _worker: WorkerId) -> Poller<Self::Stream> {
+    fn poll<Svc>(self, _worker: Worker<worker::Context>) -> Poller<Self::Stream> {
         let stream = self.inner.map(|r| Ok(Some(r))).boxed();
         Poller {
             stream: BackendStream::new(stream, self.controller),

--- a/packages/apalis-core/src/request.rs
+++ b/packages/apalis-core/src/request.rs
@@ -9,7 +9,7 @@ use crate::{
     error::Error,
     poller::Poller,
     task::{attempt::Attempt, namespace::Namespace, task_id::TaskId},
-    worker::WorkerId,
+    worker::{Context, Worker},
     Backend,
 };
 
@@ -111,10 +111,10 @@ impl<T, Res, Ctx> Backend<Request<T, Ctx>, Res> for RequestStream<Request<T, Ctx
 
     type Layer = Identity;
 
-    fn poll<Svc>(self, _worker: WorkerId) -> Poller<Self::Stream> {
+    fn poll<Svc>(self, _worker: Worker<Context>) -> Poller<Self::Stream> {
         Poller {
             stream: self,
-            heartbeat: Box::pin(async {}),
+            heartbeat: Box::pin(futures::future::pending()),
             layer: Identity::new(),
         }
     }

--- a/packages/apalis-core/src/request.rs
+++ b/packages/apalis-core/src/request.rs
@@ -111,7 +111,7 @@ impl<T, Res, Ctx> Backend<Request<T, Ctx>, Res> for RequestStream<Request<T, Ctx
 
     type Layer = Identity;
 
-    fn poll<Svc>(self, _worker: Worker<Context>) -> Poller<Self::Stream> {
+    fn poll<Svc>(self, _worker: &Worker<Context>) -> Poller<Self::Stream> {
         Poller {
             stream: self,
             heartbeat: Box::pin(futures::future::pending()),

--- a/packages/apalis-core/src/worker/mod.rs
+++ b/packages/apalis-core/src/worker/mod.rs
@@ -303,7 +303,7 @@ impl<S, P> Worker<Ready<S, P>> {
         };
         let backend = self.state.backend;
         let service = self.state.service;
-        let poller = backend.poll::<S>(worker.clone());
+        let poller = backend.poll::<S>(&worker);
         let stream = poller.stream;
         let heartbeat = poller.heartbeat.boxed();
         let layer = poller.layer;

--- a/packages/apalis-core/src/worker/mod.rs
+++ b/packages/apalis-core/src/worker/mod.rs
@@ -303,7 +303,7 @@ impl<S, P> Worker<Ready<S, P>> {
         };
         let backend = self.state.backend;
         let service = self.state.service;
-        let poller = backend.poll::<S>(worker_id.clone());
+        let poller = backend.poll::<S>(worker.clone());
         let stream = poller.stream;
         let heartbeat = poller.heartbeat.boxed();
         let layer = poller.layer;
@@ -387,7 +387,7 @@ impl Future for Runnable {
 }
 
 /// Stores the Workers context
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Context {
     task_count: Arc<AtomicUsize>,
     wakers: Arc<Mutex<Vec<Waker>>>,

--- a/packages/apalis-cron/src/lib.rs
+++ b/packages/apalis-cron/src/lib.rs
@@ -57,11 +57,11 @@
 //! }
 //! ```
 
-use apalis_core::worker::{Context, Worker};
 use apalis_core::layers::Identity;
 use apalis_core::poller::Poller;
 use apalis_core::request::RequestStream;
 use apalis_core::task::namespace::Namespace;
+use apalis_core::worker::{Context, Worker};
 use apalis_core::Backend;
 use apalis_core::{error::Error, request::Request};
 use chrono::{DateTime, TimeZone, Utc};

--- a/packages/apalis-cron/src/lib.rs
+++ b/packages/apalis-cron/src/lib.rs
@@ -57,11 +57,11 @@
 //! }
 //! ```
 
+use apalis_core::worker::{Context, Worker};
 use apalis_core::layers::Identity;
 use apalis_core::poller::Poller;
 use apalis_core::request::RequestStream;
 use apalis_core::task::namespace::Namespace;
-use apalis_core::worker::WorkerId;
 use apalis_core::Backend;
 use apalis_core::{error::Error, request::Request};
 use chrono::{DateTime, TimeZone, Utc};
@@ -145,8 +145,8 @@ where
 
     type Layer = Identity;
 
-    fn poll<Svc>(self, _worker: WorkerId) -> Poller<Self::Stream, Self::Layer> {
+    fn poll<Svc>(self, _worker: Worker<Context>) -> Poller<Self::Stream, Self::Layer> {
         let stream = self.into_stream();
-        Poller::new(stream, async {})
+        Poller::new(stream, futures::future::pending())
     }
 }

--- a/packages/apalis-cron/src/lib.rs
+++ b/packages/apalis-cron/src/lib.rs
@@ -145,7 +145,7 @@ where
 
     type Layer = Identity;
 
-    fn poll<Svc>(self, _worker: Worker<Context>) -> Poller<Self::Stream, Self::Layer> {
+    fn poll<Svc>(self, _worker: &Worker<Context>) -> Poller<Self::Stream, Self::Layer> {
         let stream = self.into_stream();
         Poller::new(stream, futures::future::pending())
     }

--- a/packages/apalis-redis/Cargo.toml
+++ b/packages/apalis-redis/Cargo.toml
@@ -34,6 +34,7 @@ tokio = { version = "1", features = ["rt", "net"], optional = true }
 async-std = { version = "1.13.0", optional = true }
 async-trait = "0.1.80"
 tower = "0.4"
+thiserror = "1"
 
 
 [dev-dependencies]

--- a/packages/apalis-redis/src/lib.rs
+++ b/packages/apalis-redis/src/lib.rs
@@ -31,6 +31,6 @@ mod storage;
 pub use storage::connect;
 pub use storage::Config;
 pub use storage::RedisContext;
+pub use storage::RedisPollError;
 pub use storage::RedisQueueInfo;
 pub use storage::RedisStorage;
-pub use storage::RedisPollError;

--- a/packages/apalis-redis/src/lib.rs
+++ b/packages/apalis-redis/src/lib.rs
@@ -33,3 +33,4 @@ pub use storage::Config;
 pub use storage::RedisContext;
 pub use storage::RedisQueueInfo;
 pub use storage::RedisStorage;
+pub use storage::RedisPollError;

--- a/packages/apalis-redis/src/storage.rs
+++ b/packages/apalis-redis/src/storage.rs
@@ -440,7 +440,7 @@ where
 
     fn poll<Svc: Service<Request<T, RedisContext>>>(
         mut self,
-        worker: Worker<apalis_core::worker::Context>,
+        worker: &Worker<apalis_core::worker::Context>,
     ) -> Poller<Self::Stream, Self::Layer> {
         let (mut tx, rx) = mpsc::channel(self.config.buffer_size);
         let (ack, ack_rx) = mpsc::channel(self.config.buffer_size);
@@ -448,6 +448,7 @@ where
         let controller = self.controller.clone();
         let config = self.config.clone();
         let stream: RequestStream<Request<T, RedisContext>> = Box::pin(rx);
+        let worker = worker.clone();
         let heartbeat = async move {
             let mut reenqueue_orphaned_stm =
                 apalis_core::interval::interval(config.poll_interval).fuse();

--- a/packages/apalis-sql/Cargo.toml
+++ b/packages/apalis-sql/Cargo.toml
@@ -37,6 +37,7 @@ tokio = { version = "1", features = ["rt", "net"], optional = true }
 futures-lite = "2.3.0"
 async-std = { version = "1.13.0", optional = true }
 chrono = { version = "0.4", features = ["serde"] }
+thiserror = "1"
 
 
 [dev-dependencies]

--- a/packages/apalis-sql/src/mysql.rs
+++ b/packages/apalis-sql/src/mysql.rs
@@ -400,7 +400,7 @@ where
 
     type Layer = AckLayer<MysqlStorage<Req, C>, Req, SqlContext, Res>;
 
-    fn poll<Svc>(self, worker: Worker<Context>) -> Poller<Self::Stream, Self::Layer> {
+    fn poll<Svc>(self, worker: &Worker<Context>) -> Poller<Self::Stream, Self::Layer> {
         let layer = AckLayer::new(self.clone());
         let config = self.config.clone();
         let controller = self.controller.clone();
@@ -461,6 +461,7 @@ where
                 apalis_core::sleep(config.keep_alive).await;
             }
         };
+        let w = worker.clone();
         let reenqueue_beat = async move {
             loop {
                 let dead_since = Utc::now()
@@ -476,7 +477,7 @@ where
                     )
                     .await
                 {
-                    worker.emit(Event::Error(Box::new(
+                    w.emit(Event::Error(Box::new(
                         MysqlPollError::ReenqueueOrphanedError(e),
                     )));
                 }

--- a/packages/apalis-sql/src/mysql.rs
+++ b/packages/apalis-sql/src/mysql.rs
@@ -1,5 +1,5 @@
 use apalis_core::codec::json::JsonCodec;
-use apalis_core::error::Error;
+use apalis_core::error::{BoxDynError, Error};
 use apalis_core::layers::{Ack, AckLayer};
 use apalis_core::notify::Notify;
 use apalis_core::poller::controller::Controller;
@@ -10,7 +10,7 @@ use apalis_core::response::Response;
 use apalis_core::storage::Storage;
 use apalis_core::task::namespace::Namespace;
 use apalis_core::task::task_id::TaskId;
-use apalis_core::worker::WorkerId;
+use apalis_core::worker::{Context, Event, Worker, WorkerId};
 use apalis_core::{Backend, Codec};
 use async_stream::try_stream;
 use chrono::{DateTime, Utc};
@@ -180,8 +180,7 @@ where
                         yield {
                             let (req, ctx) = job.req.take_parts();
                             let req = C::decode(req)
-                                .map_err(|e| sqlx::Error::Io(io::Error::new(io::ErrorKind::InvalidData, e)))
-                                .unwrap();
+                                .map_err(|e| sqlx::Error::Io(io::Error::new(io::ErrorKind::InvalidData, e)))?;
                             let mut req: Request<T, SqlContext> = Request::new_with_parts(req, ctx);
                             req.parts.namespace = Some(Namespace(self.config.namespace.clone()));
                             Some(req)
@@ -371,16 +370,37 @@ where
     }
 }
 
+/// Errors that can occur while polling a MySQL database.
+#[derive(thiserror::Error, Debug)]
+pub enum MysqlPollError {
+    /// Error during task acknowledgment.
+    #[error("Encountered an error during ACK: `{0}`")]
+    AckError(sqlx::Error),
+
+    /// Error during result encoding.
+    #[error("Encountered an error during encoding the result: {0}")]
+    CodecError(BoxDynError),
+
+    /// Error during a keep-alive heartbeat.
+    #[error("Encountered an error during KeepAlive heartbeat: `{0}`")]
+    KeepAliveError(sqlx::Error),
+
+    /// Error during re-enqueuing orphaned tasks.
+    #[error("Encountered an error during ReenqueueOrphaned heartbeat: `{0}`")]
+    ReenqueueOrphanedError(sqlx::Error),
+}
+
 impl<Req, Res, C> Backend<Request<Req, SqlContext>, Res> for MysqlStorage<Req, C>
 where
     Req: Serialize + DeserializeOwned + Sync + Send + Unpin + 'static,
     C: Debug + Codec<Compact = Value> + Clone + Send + 'static + Sync,
+    C::Error: std::error::Error + 'static + Send + Sync,
 {
     type Stream = BackendStream<RequestStream<Request<Req, SqlContext>>>;
 
     type Layer = AckLayer<MysqlStorage<Req, C>, Req, SqlContext, Res>;
 
-    fn poll<Svc>(self, worker: WorkerId) -> Poller<Self::Stream, Self::Layer> {
+    fn poll<Svc>(self, worker: Worker<Context>) -> Poller<Self::Stream, Self::Layer> {
         let layer = AckLayer::new(self.clone());
         let config = self.config.clone();
         let controller = self.controller.clone();
@@ -389,9 +409,10 @@ where
         let mut hb_storage = self.clone();
         let requeue_storage = self.clone();
         let stream = self
-            .stream_jobs(&worker, config.poll_interval, config.buffer_size)
+            .stream_jobs(worker.id(), config.poll_interval, config.buffer_size)
             .map_err(|e| Error::SourceError(Arc::new(Box::new(e))));
         let stream = BackendStream::new(stream.boxed(), controller);
+        let w = worker.clone();
 
         let ack_heartbeat = async move {
             while let Some(ids) = ack_notify
@@ -403,28 +424,39 @@ where
                 for (ctx, res) in ids {
                     let query = "UPDATE jobs SET status = ?, done_at = now(), last_error = ? WHERE id = ? AND lock_by = ?";
                     let query = sqlx::query(query);
-                    let query = query
-                        .bind(calculate_status(&res.inner).to_string())
-                        .bind(
-                            serde_json::to_string(&res.inner.as_ref().map_err(|e| e.to_string()))
-                                .unwrap(),
-                        )
-                        .bind(res.task_id.to_string())
-                        .bind(ctx.lock_by().as_ref().unwrap().to_string());
-                    if let Err(e) = query.execute(&pool).await {
-                        error!("Ack failed: {e}");
+                    let last_result =
+                        C::encode(res.inner.as_ref().map_err(|e| e.to_string())).map_err(Box::new);
+                    match (last_result, ctx.lock_by()) {
+                        (Ok(val), Some(worker_id)) => {
+                            let query = query
+                                .bind(calculate_status(&res.inner).to_string())
+                                .bind(val)
+                                .bind(res.task_id.to_string())
+                                .bind(worker_id.to_string());
+                            if let Err(e) = query.execute(&pool).await {
+                                w.emit(Event::Error(Box::new(MysqlPollError::AckError(e))));
+                            }
+                        }
+                        (Err(error), Some(_)) => {
+                            w.emit(Event::Error(Box::new(MysqlPollError::CodecError(error))));
+                        }
+                        _ => {
+                            unreachable!(
+                                "Attempted to ACK without a worker attached. This is a bug, File it on the repo"
+                            );
+                        }
                     }
                 }
 
                 apalis_core::sleep(config.poll_interval).await;
             }
         };
-
+        let w = worker.clone();
         let heartbeat = async move {
             loop {
                 let now = Utc::now();
-                if let Err(e) = hb_storage.keep_alive_at::<Self::Layer>(&worker, now).await {
-                    error!("Heartbeat failed: {e}");
+                if let Err(e) = hb_storage.keep_alive_at::<Self::Layer>(w.id(), now).await {
+                    w.emit(Event::Error(Box::new(MysqlPollError::KeepAliveError(e))));
                 }
                 apalis_core::sleep(config.keep_alive).await;
             }
@@ -432,12 +464,21 @@ where
         let reenqueue_beat = async move {
             loop {
                 let dead_since = Utc::now()
-                    - chrono::Duration::from_std(config.reenqueue_orphaned_after).unwrap();
+                    - chrono::Duration::from_std(config.reenqueue_orphaned_after)
+                        .expect("Could not calculate dead since");
                 if let Err(e) = requeue_storage
-                    .reenqueue_orphaned(config.buffer_size.try_into().unwrap(), dead_since)
+                    .reenqueue_orphaned(
+                        config
+                            .buffer_size
+                            .try_into()
+                            .expect("Could not convert usize to i32"),
+                        dead_since,
+                    )
                     .await
                 {
-                    error!("ReenqueueOrphaned failed: {e}");
+                    worker.emit(Event::Error(Box::new(
+                        MysqlPollError::ReenqueueOrphanedError(e),
+                    )));
                 }
                 apalis_core::sleep(config.poll_interval).await;
             }
@@ -463,7 +504,10 @@ where
     type AckError = sqlx::Error;
     async fn ack(&mut self, ctx: &Self::Context, res: &Response<Res>) -> Result<(), sqlx::Error> {
         self.ack_notify
-            .notify((ctx.clone(), res.map(|res| C::encode(res).unwrap())))
+            .notify((
+                ctx.clone(),
+                res.map(|res| C::encode(res).expect("Could not encode result")),
+            ))
             .map_err(|e| sqlx::Error::Io(io::Error::new(io::ErrorKind::BrokenPipe, e)))?;
 
         Ok(())

--- a/packages/apalis-sql/src/postgres.rs
+++ b/packages/apalis-sql/src/postgres.rs
@@ -156,7 +156,7 @@ where
 
     type Layer = AckLayer<PostgresStorage<T, C>, T, SqlContext, Res>;
 
-    fn poll<Svc>(mut self, worker: Worker<Context>) -> Poller<Self::Stream, Self::Layer> {
+    fn poll<Svc>(mut self, worker: &Worker<Context>) -> Poller<Self::Stream, Self::Layer> {
         let layer = AckLayer::new(self.clone());
         let subscription = self.subscription.clone();
         let config = self.config.clone();
@@ -164,6 +164,7 @@ where
         let (mut tx, rx) = mpsc::channel(self.config.buffer_size);
         let ack_notify = self.ack_notify.clone();
         let pool = self.pool.clone();
+        let worker = worker.clone();
         let heartbeat = async move {
             let mut keep_alive_stm = apalis_core::interval::interval(config.keep_alive).fuse();
             let mut reenqueue_orphaned_stm =

--- a/packages/apalis-sql/src/sqlite.rs
+++ b/packages/apalis-sql/src/sqlite.rs
@@ -11,7 +11,7 @@ use apalis_core::response::Response;
 use apalis_core::storage::Storage;
 use apalis_core::task::namespace::Namespace;
 use apalis_core::task::task_id::TaskId;
-use apalis_core::worker::WorkerId;
+use apalis_core::worker::{Context, Event, Worker, WorkerId};
 use apalis_core::{Backend, Codec};
 use async_stream::try_stream;
 use chrono::{DateTime, Utc};
@@ -448,40 +448,62 @@ impl<T> SqliteStorage<T> {
     }
 }
 
+/// Errors that can occur while polling an SQLite database.
+#[derive(thiserror::Error, Debug)]
+pub enum SqlitePollError {
+    /// Error during a keep-alive heartbeat.
+    #[error("Encountered an error during KeepAlive heartbeat: `{0}`")]
+    KeepAliveError(sqlx::Error),
+
+    /// Error during re-enqueuing orphaned tasks.
+    #[error("Encountered an error during ReenqueueOrphaned heartbeat: `{0}`")]
+    ReenqueueOrphanedError(sqlx::Error),
+}
+
 impl<T: Serialize + DeserializeOwned + Sync + Send + Unpin + 'static, Res>
     Backend<Request<T, SqlContext>, Res> for SqliteStorage<T>
 {
     type Stream = BackendStream<RequestStream<Request<T, SqlContext>>>;
     type Layer = AckLayer<SqliteStorage<T>, T, SqlContext, Res>;
 
-    fn poll<Svc>(mut self, worker: WorkerId) -> Poller<Self::Stream, Self::Layer> {
+    fn poll<Svc>(mut self, worker: Worker<Context>) -> Poller<Self::Stream, Self::Layer> {
         let layer = AckLayer::new(self.clone());
         let config = self.config.clone();
         let controller = self.controller.clone();
         let stream = self
-            .stream_jobs(&worker, config.poll_interval, config.buffer_size)
+            .stream_jobs(worker.id(), config.poll_interval, config.buffer_size)
             .map_err(|e| Error::SourceError(Arc::new(Box::new(e))));
         let stream = BackendStream::new(stream.boxed(), controller);
         let requeue_storage = self.clone();
+        let w = worker.clone();
         let heartbeat = async move {
             loop {
                 let now: i64 = Utc::now().timestamp();
-                self.keep_alive_at::<Self::Layer>(&worker, now)
-                    .await
-                    .unwrap();
+                if let Err(e) = self.keep_alive_at::<Self::Layer>(worker.id(), now).await {
+                    worker.emit(Event::Error(Box::new(SqlitePollError::KeepAliveError(e))));
+                }
                 apalis_core::sleep(Duration::from_secs(30)).await;
             }
         }
         .boxed();
+
         let reenqueue_beat = async move {
             loop {
                 let dead_since = Utc::now()
                     - chrono::Duration::from_std(config.reenqueue_orphaned_after).unwrap();
                 if let Err(e) = requeue_storage
-                    .reenqueue_orphaned(config.buffer_size.try_into().unwrap(), dead_since)
+                    .reenqueue_orphaned(
+                        config
+                            .buffer_size
+                            .try_into()
+                            .expect("could not convert usize to i32"),
+                        dead_since,
+                    )
                     .await
                 {
-                    error!("ReenqueueOrphaned failed: {e}");
+                    w.emit(Event::Error(Box::new(
+                        SqlitePollError::ReenqueueOrphanedError(e),
+                    )));
                 }
                 apalis_core::sleep(config.poll_interval).await;
             }
@@ -507,7 +529,12 @@ impl<T: Sync + Send, Res: Serialize + Sync> Ack<T, Res> for SqliteStorage<T> {
             .map_err(|e| sqlx::Error::Io(io::Error::new(io::ErrorKind::InvalidData, e)))?;
         sqlx::query(query)
             .bind(res.task_id.to_string())
-            .bind(ctx.lock_by().as_ref().unwrap().to_string())
+            .bind(
+                ctx.lock_by()
+                    .as_ref()
+                    .expect("Task is not locked")
+                    .to_string(),
+            )
             .bind(result)
             .bind(calculate_status(&res.inner).to_string())
             .execute(&pool)


### PR DESCRIPTION
Basically this allows workers to receive unstarted worker instance making it more useable eg  emit errors.