### PR TITLE
fix: re-export redis ConnectionManager & RedisError

### DIFF
--- a/packages/apalis-redis/src/lib.rs
+++ b/packages/apalis-redis/src/lib.rs
@@ -29,6 +29,7 @@
 
 mod expose;
 mod storage;
+pub use redis::{aio::ConnectionManager, RedisError};
 pub use storage::connect;
 pub use storage::Config;
 pub use storage::RedisContext;


### PR DESCRIPTION

Fix #464