### PR TITLE
fix: handle only the latest waker

### DIFF
--- a/packages/apalis-core/src/worker/mod.rs
+++ b/packages/apalis-core/src/worker/mod.rs
@@ -471,7 +471,7 @@ impl Context {
     pub(crate) fn wake(&self) {
         if let Ok(waker) = self.waker.lock() {
             if let Some(waker) = &*waker {
-                waker.clone().wake();
+                waker.wake_by_ref();
             }
         }
     }


### PR DESCRIPTION
This attempts to resolve #477 