### PR TITLE
fix: handle vacuuming correctly for backends

### DIFF
--- a/packages/apalis-redis/src/storage.rs
+++ b/packages/apalis-redis/src/storage.rs
@@ -818,7 +818,7 @@ where
     async fn vacuum(&mut self) -> Result<usize, RedisError> {
         let vacuum_script = self.scripts.vacuum.clone();
         vacuum_script
-            .key(self.config.dead_jobs_set())
+            .key(self.config.done_jobs_set())
             .key(self.config.job_data_hash())
             .invoke_async(&mut self.conn)
             .await


### PR DESCRIPTION
Vacuuming is not well tested and documented. This PR intends to fix that:

### Backends
- [ ] Sqlite
- [x] Redis
- [ ] Postgres
- [ ] Mysql

### Testing and Docs
- [ ] Generic tests for all
- [ ] Add docs for how to vacuum