### PR TITLE
Add keep_alive() call when an error occurs in fetch_next(), to prevent permanent failure when redis restarts

### DIFF
--- a/packages/apalis-redis/src/storage.rs
+++ b/packages/apalis-redis/src/storage.rs
@@ -632,7 +632,9 @@ where
             }
             Err(e) => {
                 warn!("An error occurred during streaming jobs: {e}");
-                self.keep_alive(worker_id).await?;
+                if matches!(e.kind(), ErrorKind::ResponseError) && e.to_string().contains("consumer not registered script") {
+                    self.keep_alive(worker_id).await?;
+                }
                 Err(e)
             }
         }

--- a/packages/apalis-redis/src/storage.rs
+++ b/packages/apalis-redis/src/storage.rs
@@ -632,6 +632,7 @@ where
             }
             Err(e) => {
                 warn!("An error occurred during streaming jobs: {e}");
+                self.keep_alive(worker_id).await?;
                 Err(e)
             }
         }

--- a/packages/apalis-redis/src/storage.rs
+++ b/packages/apalis-redis/src/storage.rs
@@ -632,7 +632,9 @@ where
             }
             Err(e) => {
                 warn!("An error occurred during streaming jobs: {e}");
-                if matches!(e.kind(), ErrorKind::ResponseError) && e.to_string().contains("consumer not registered script") {
+                if matches!(e.kind(), ErrorKind::ResponseError)
+                    && e.to_string().contains("consumer not registered script")
+                {
                     self.keep_alive(worker_id).await?;
                 }
                 Err(e)


### PR DESCRIPTION
As per title, without this change when redis restarts, it seems apalis get's stuck repeating this error over and over:
```
WARN  An error occurred during streaming jobs: An error was signalled by the server - ResponseError: user_script:15: consumer not registered script: e3ac73ae44f02d04176688b08c26ed751417cdb0, on @user_script:15.
```

After this change, on error `keep_alive()` will re-register, so it's fixed on the next call.