### PR TITLE
fix: reenqueue oprphaned before starting streaming

### DIFF
--- a/packages/apalis-redis/src/storage.rs
+++ b/packages/apalis-redis/src/storage.rs
@@ -451,10 +451,15 @@ where
         let worker = worker.clone();
         let heartbeat = async move {
             // Lets reenqueue any jobs that belonged to this worker in case of a death
-            if let Err(e) = self.reenqueue_orphaned((config.buffer_size * 10) as i32, Utc::now()).await {
-                worker.emit(Event::Error(Box::new(RedisPollError::ReenqueueOrphanedError(e))));
-            } 
-            
+            if let Err(e) = self
+                .reenqueue_orphaned((config.buffer_size * 10) as i32, Utc::now())
+                .await
+            {
+                worker.emit(Event::Error(Box::new(
+                    RedisPollError::ReenqueueOrphanedError(e),
+                )));
+            }
+
             let mut reenqueue_orphaned_stm =
                 apalis_core::interval::interval(config.poll_interval).fuse();
 

--- a/packages/apalis-redis/src/storage.rs
+++ b/packages/apalis-redis/src/storage.rs
@@ -450,6 +450,11 @@ where
         let stream: RequestStream<Request<T, RedisContext>> = Box::pin(rx);
         let worker = worker.clone();
         let heartbeat = async move {
+            // Lets reenqueue any jobs that belonged to this worker in case of a death
+            if let Err(e) = self.reenqueue_orphaned((config.buffer_size * 10) as i32, Utc::now()).await {
+                worker.emit(Event::Error(Box::new(RedisPollError::ReenqueueOrphanedError(e))));
+            } 
+            
             let mut reenqueue_orphaned_stm =
                 apalis_core::interval::interval(config.poll_interval).fuse();
 

--- a/packages/apalis-sql/src/mysql.rs
+++ b/packages/apalis-sql/src/mysql.rs
@@ -462,6 +462,11 @@ where
         };
         let w = worker.clone();
         let heartbeat = async move {
+            // Lets reenqueue any jobs that belonged to this worker in case of a death
+            if let Err(e) = hb_storage.reenqueue_orphaned((config.buffer_size * 10) as i32, Utc::now()).await {
+                w.emit(Event::Error(Box::new(MysqlPollError::ReenqueueOrphanedError(e))));
+            } 
+            
             loop {
                 let now = Utc::now();
                 if let Err(e) = hb_storage.keep_alive_at::<Self::Layer>(w.id(), now).await {

--- a/packages/apalis-sql/src/mysql.rs
+++ b/packages/apalis-sql/src/mysql.rs
@@ -463,10 +463,15 @@ where
         let w = worker.clone();
         let heartbeat = async move {
             // Lets reenqueue any jobs that belonged to this worker in case of a death
-            if let Err(e) = hb_storage.reenqueue_orphaned((config.buffer_size * 10) as i32, Utc::now()).await {
-                w.emit(Event::Error(Box::new(MysqlPollError::ReenqueueOrphanedError(e))));
-            } 
-            
+            if let Err(e) = hb_storage
+                .reenqueue_orphaned((config.buffer_size * 10) as i32, Utc::now())
+                .await
+            {
+                w.emit(Event::Error(Box::new(
+                    MysqlPollError::ReenqueueOrphanedError(e),
+                )));
+            }
+
             loop {
                 let now = Utc::now();
                 if let Err(e) = hb_storage.keep_alive_at::<Self::Layer>(w.id(), now).await {

--- a/packages/apalis-sql/src/postgres.rs
+++ b/packages/apalis-sql/src/postgres.rs
@@ -167,6 +167,11 @@ where
         let pool = self.pool.clone();
         let worker = worker.clone();
         let heartbeat = async move {
+            // Lets reenqueue any jobs that belonged to this worker in case of a death
+            if let Err(e) = self.reenqueue_orphaned((config.buffer_size * 10) as i32, Utc::now()).await {
+                worker.emit(Event::Error(Box::new(PgPollError::ReenqueueOrphanedError(e))));
+            } 
+
             let mut keep_alive_stm = apalis_core::interval::interval(config.keep_alive).fuse();
             let mut reenqueue_orphaned_stm =
                 apalis_core::interval::interval(config.poll_interval).fuse();

--- a/packages/apalis-sql/src/postgres.rs
+++ b/packages/apalis-sql/src/postgres.rs
@@ -168,9 +168,14 @@ where
         let worker = worker.clone();
         let heartbeat = async move {
             // Lets reenqueue any jobs that belonged to this worker in case of a death
-            if let Err(e) = self.reenqueue_orphaned((config.buffer_size * 10) as i32, Utc::now()).await {
-                worker.emit(Event::Error(Box::new(PgPollError::ReenqueueOrphanedError(e))));
-            } 
+            if let Err(e) = self
+                .reenqueue_orphaned((config.buffer_size * 10) as i32, Utc::now())
+                .await
+            {
+                worker.emit(Event::Error(Box::new(PgPollError::ReenqueueOrphanedError(
+                    e,
+                ))));
+            }
 
             let mut keep_alive_stm = apalis_core::interval::interval(config.keep_alive).fuse();
             let mut reenqueue_orphaned_stm =


### PR DESCRIPTION
This calls `reenqueue_orphaned` before starting to stream jobs.
This allows recovering your worker state. This logic will be improved in future releases but this is a quickfix for #504 