### PR TITLE
add: retry layer integration with task handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ members = [
   "examples/unmonitored-worker",
   "examples/fn-args",
   "examples/persisted-cron",
-  "examples/rest-api",
+  "examples/rest-api", "examples/retries",
 ]
 
 

--- a/examples/postgres/src/main.rs
+++ b/examples/postgres/src/main.rs
@@ -49,8 +49,8 @@ async fn main() -> Result<()> {
     Monitor::new()
         .register({
             WorkerBuilder::new("tasty-orange")
-                .enable_tracing()
                 .retry(RetryPolicy::retries(5))
+                .enable_tracing()
                 .backend(pg)
                 .build_fn(send_email)
         })

--- a/examples/retries/Cargo.toml
+++ b/examples/retries/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
-name = "postgres-example"
+name = "retries-example"
 version = "0.1.0"
-authors = ["Njuguna Mureithi <mureithinjuguna@gmail.com>"]
-edition = "2018"
-license = "MIT OR Apache-2.0"
+edition.workspace = true
+repository.workspace = true
 
 [dependencies]
 anyhow = "1"
-apalis = { path = "../../", features = ["retry"] }
+apalis = { path = "../../", features = ["retry", "limit"] }
 apalis-sql = { path = "../../packages/apalis-sql", features = [
     "postgres",
     "tokio-comp",

--- a/examples/retries/src/main.rs
+++ b/examples/retries/src/main.rs
@@ -1,0 +1,97 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use apalis::layers::retry::backoff::MakeBackoff;
+use apalis::layers::retry::HasherRng;
+use apalis::layers::retry::{backoff::ExponentialBackoffMaker, RetryPolicy};
+
+use apalis::prelude::*;
+use apalis_sql::{
+    postgres::{PgPool, PostgresStorage},
+    Config,
+};
+use email_service::{send_email, Email};
+use tracing::{debug, info};
+
+/// Produces jobs to check retries
+/// See [send_email] for the logic explained here
+async fn produce_jobs(storage: &mut PostgresStorage<Email>) -> Result<()> {
+    storage
+        .push(Email {
+            // Valid email should just run once (attempts = 1)
+            to: format!("test{}@example.com", 0),
+            text: "Test background job from apalis".to_string(),
+            subject: "Background email job".to_string(),
+        })
+        .await?;
+    storage
+        .push(Email {
+            // Invalid email, should fail and retry 3 times (attempts = 4)
+            to: "test.at.example.com".to_owned(),
+            text: "Test background job from apalis".to_string(),
+            subject: "Background email job".to_string(),
+        })
+        .await?;
+    storage
+        .push(Email {
+            // Invalid character, job will abort. Should only run once (attempts = 1)
+            to: "A@b@c@example.com".to_owned(),
+            text: "Test background job from apalis".to_string(),
+            subject: "Background email job".to_string(),
+        })
+        .await?;
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    std::env::set_var("RUST_LOG", "debug,sqlx::query=error");
+    tracing_subscriber::fmt::init();
+    let database_url = std::env::var("DATABASE_URL").expect("Must specify path to db");
+
+    let pool = PgPool::connect(&database_url).await?;
+    PostgresStorage::setup(&pool)
+        .await
+        .expect("unable to run migrations for postgres");
+
+    let mut pg_with_retry =
+        PostgresStorage::new_with_config(pool.clone(), Config::new("apalis::Email"));
+    let mut pg_with_backoff =
+        PostgresStorage::new_with_config(pool.clone(), Config::new("apalis::BackoffEmail"));
+
+    produce_jobs(&mut pg_with_retry).await?;
+    produce_jobs(&mut pg_with_backoff).await?;
+
+    Monitor::new()
+        .register({
+            WorkerBuilder::new("tasty-orange")
+                // Ensure this is above tracing layer, else you wont see traces
+                .retry(RetryPolicy::retries(3))
+                .enable_tracing()
+                .backend(pg_with_retry)
+                .build_fn(send_email)
+        })
+        .register({
+            let backoff = ExponentialBackoffMaker::new(
+                Duration::from_millis(1000),
+                Duration::from_millis(5000),
+                1.25,
+                HasherRng::default(),
+            )?
+            .make_backoff();
+
+            WorkerBuilder::new("tasty-orange-with-backoff")
+                .retry(RetryPolicy::retries(3).with_backoff(backoff))
+                .enable_tracing()
+                .backend(pg_with_backoff)
+                .build_fn(send_email)
+        })
+        .on_event(|e| debug!("{e}"))
+        .run_with_signal(async {
+            tokio::signal::ctrl_c().await?;
+            info!("Shutting down the system");
+            Ok(())
+        })
+        .await?;
+    Ok(())
+}

--- a/src/layers/retry/mod.rs
+++ b/src/layers/retry/mod.rs
@@ -1,14 +1,81 @@
-use futures::future;
-use tower::retry::Policy;
+use futures::{future::BoxFuture, FutureExt};
+use std::fmt;
+use std::sync::Arc;
+use tower::retry::backoff::Backoff;
 
 use apalis_core::{error::Error, request::Request};
-/// Re-export from [`RetryLayer`]
-///
-/// [`RetryLayer`]: tower::retry::RetryLayer
-pub use tower::retry::RetryLayer;
+
+/// Re-exports from [`tower::retry`]
+pub use tower::retry::*;
+/// Re-exports from [`tower::util`]
+pub use tower::util::rng::HasherRng;
 
 type Req<T, Ctx> = Request<T, Ctx>;
 type Err = Error;
+
+/// Retries a task with backoff
+#[derive(Clone, Debug)]
+pub struct BackoffRetryPolicy<B> {
+    retries: usize,
+    backoff: B,
+}
+
+impl<B> BackoffRetryPolicy<B> {
+    /// Build a new retry policy with backoff
+    pub fn new(retries: usize, backoff: B) -> Self {
+        Self { retries, backoff }
+    }
+}
+
+impl<T, Res, Ctx, B> Policy<Req<T, Ctx>, Res, Err> for BackoffRetryPolicy<B>
+where
+    T: Clone,
+    Ctx: Clone,
+    B: Backoff,
+    B::Future: Send + 'static,
+{
+    type Future = BoxFuture<'static, ()>;
+
+    fn retry(
+        &mut self,
+        req: &mut Req<T, Ctx>,
+        result: &mut Result<Res, Err>,
+    ) -> Option<Self::Future> {
+        let attempt = req.parts.attempt.current();
+        match result.as_mut() {
+            Ok(_) => {
+                // Treat all `Response`s as success,
+                // so don't retry...
+                None
+            }
+            Err(Err::Abort(_)) => return None,
+            Err(err) => {
+                if self.retries == 0 {
+                    *err = Err::Abort(Arc::new(Box::new(RetryPolicyError::ZeroRetries(
+                        err.clone(),
+                    ))));
+                    return None;
+                } else if self.retries >= attempt {
+                    let counter = req.parts.attempt.clone();
+                    return Some(Box::pin(self.backoff.next_backoff().map(move |_| {
+                        counter.increment();
+                    })));
+                } else {
+                    *err = Err::Abort(Arc::new(Box::new(RetryPolicyError::OutOfRetries {
+                        current_attempt: attempt,
+                        inner: err.clone(),
+                    })));
+                    return None;
+                }
+            }
+        }
+    }
+
+    fn clone_request(&mut self, req: &Req<T, Ctx>) -> Option<Req<T, Ctx>> {
+        let req = req.clone();
+        Some(req)
+    }
+}
 
 /// Retries a task instantly for `retries`
 #[derive(Clone, Debug)]
@@ -18,14 +85,22 @@ pub struct RetryPolicy {
 
 impl Default for RetryPolicy {
     fn default() -> Self {
-        Self { retries: 25 }
+        Self { retries: 5 }
     }
 }
 
 impl RetryPolicy {
     /// Set the number of replies
-    pub fn retries(count: usize) -> Self {
-        Self { retries: count }
+    pub fn retries(retries: usize) -> Self {
+        Self { retries }
+    }
+
+    /// Include a backoff to the retry policy
+    pub fn with_backoff<B: Backoff>(self, backoff: B) -> BackoffRetryPolicy<B> {
+        BackoffRetryPolicy {
+            retries: self.retries,
+            backoff,
+        }
     }
 }
 
@@ -34,29 +109,87 @@ where
     T: Clone,
     Ctx: Clone,
 {
-    type Future = future::Ready<()>;
+    type Future = std::future::Ready<()>;
 
     fn retry(
         &mut self,
         req: &mut Req<T, Ctx>,
         result: &mut Result<Res, Err>,
     ) -> Option<Self::Future> {
-        let attempt = &req.parts.attempt;
-        match result {
+        let attempt = req.parts.attempt.current();
+        match result.as_mut() {
             Ok(_) => {
                 // Treat all `Response`s as success,
                 // so don't retry...
                 None
             }
-            Err(_) if self.retries == 0 => None,
-            Err(_) if (self.retries - attempt.current() > 0) => Some(future::ready(())),
-            Err(_) => None,
+            Err(Err::Abort(_)) => return None,
+            Err(err) => {
+                if self.retries == 0 {
+                    *err = Err::Abort(Arc::new(Box::new(RetryPolicyError::ZeroRetries(
+                        err.clone(),
+                    ))));
+                    return None;
+                } else if self.retries >= attempt {
+                    req.parts.attempt.increment();
+                    return Some(std::future::ready(()));
+                } else {
+                    *err = Err::Abort(Arc::new(Box::new(RetryPolicyError::OutOfRetries {
+                        current_attempt: attempt,
+                        inner: err.clone(),
+                    })));
+                    return None;
+                }
+            }
         }
     }
 
     fn clone_request(&mut self, req: &Req<T, Ctx>) -> Option<Req<T, Ctx>> {
         let req = req.clone();
-        req.parts.attempt.increment();
         Some(req)
+    }
+}
+
+/// The error returned if the [RetryPolicy] forces the task to abort
+/// Works by wrapping the inner error [Error::Abort]
+#[derive(Debug)]
+pub enum RetryPolicyError {
+    /// Attempted all the retries allocated
+    OutOfRetries {
+        /// The current attempt
+        current_attempt: usize,
+        /// The last error to occur
+        inner: Error,
+    },
+    /// Retries forbidden
+    ZeroRetries(Error),
+}
+
+impl fmt::Display for RetryPolicyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RetryPolicyError::OutOfRetries {
+                current_attempt,
+                inner,
+            } => {
+                write!(
+                    f,
+                    "RetryPolicyError: Out of retries after {} attempts: {}",
+                    current_attempt, inner
+                )
+            }
+            RetryPolicyError::ZeroRetries(inner) => {
+                write!(f, "RetryPolicyError: Zero retries allowed: {}", inner)
+            }
+        }
+    }
+}
+
+impl std::error::Error for RetryPolicyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            RetryPolicyError::OutOfRetries { inner, .. } => inner.source(),
+            RetryPolicyError::ZeroRetries(inner) => inner.source(),
+        }
     }
 }

--- a/src/layers/tracing/make_span.rs
+++ b/src/layers/tracing/make_span.rs
@@ -68,7 +68,7 @@ impl<B, Ctx> MakeSpan<B, Ctx> for DefaultMakeSpan {
         // required the level argument to be static. Meaning we can't just pass
         // `self.level`.
         let task_id = req.parts.task_id.to_string();
-        let attempt = req.parts.attempt.current();
+        let attempt = &req.parts.attempt;
         let span = Span::current();
         macro_rules! make_span {
             ($level:expr) => {
@@ -77,7 +77,7 @@ impl<B, Ctx> MakeSpan<B, Ctx> for DefaultMakeSpan {
                     $level,
                     "task",
                     task_id = task_id,
-                    attempt = attempt
+                    attempt = attempt.current()
                 )
             };
         }


### PR DESCRIPTION
Integrates Retry Layer with the apalis inbuilt retry. Offers:
1. RetryPolicy
2. BackoffRetryPolicy

Resolves
- #268 
- #399 