### PR TITLE
fix: ease apalis-core default features

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "cSpell.words": [
-        "apalis",
-        "smol"
-    ],
-    "rust-analyzer.showUnlinkedFileNotification": false
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project are documented in this file.
 - **orphaned tasks**: Re-enqueue orphaned jobs before starting streaming ([#507](https://github.com/geofmureithi/apalis/pull/507))
 - **deps**: Update Rust crate `redis` to `0.28` ([#495](https://github.com/geofmureithi/apalis/pull/495))
 - **deps**: Update Rust crate `redis` to `0.29` and `deadpool-redis` to `0.20` ([#527](https://github.com/geofmureithi/apalis/pull/527))
+- **features**: fix: ease apalis-core default features ([538](https://github.com/geofmureithi/apalis/pull/538))
 
 ### Tests
 - **Integration tests**: Aborting jobs and panicking workers ([#508](https://github.com/geofmureithi/apalis/pull/508))

--- a/packages/apalis-core/Cargo.toml
+++ b/packages/apalis-core/Cargo.toml
@@ -29,7 +29,7 @@ optional = true
 
 
 [features]
-default = ["test-utils"]
+default = []
 docsrs = ["document-features"]
 sleep = ["futures-timer"]
 json = ["serde_json"]

--- a/packages/apalis-core/src/builder.rs
+++ b/packages/apalis-core/src/builder.rs
@@ -176,7 +176,6 @@ pub trait WorkerFactory<Req, Ctx, S> {
 }
 
 /// Helper trait for building new Workers from [`WorkerBuilder`]
-
 pub trait WorkerFactoryFn<Req, Ctx, F, FnArgs> {
     /// The request source for the [`Worker`]
     type Source;

--- a/packages/apalis-core/src/lib.rs
+++ b/packages/apalis-core/src/lib.rs
@@ -297,12 +297,16 @@ pub mod test_utils {
             self.should_next.store(true, Ordering::Release);
             #[cfg(feature = "sleep")]
             let fut = async {
-                crate::sleep(std::time::Duration::from_secs(2)).boxed().await;
-            }.boxed();
+                crate::sleep(std::time::Duration::from_secs(2))
+                    .boxed()
+                    .await;
+            }
+            .boxed();
             #[cfg(not(feature = "sleep"))]
             let fut = async {
                 std::future::pending::<()>().await;
-            }.boxed();
+            }
+            .boxed();
 
             let res = futures::future::select(self.res_rx.next(), fut).await;
             match res {

--- a/packages/apalis-core/src/lib.rs
+++ b/packages/apalis-core/src/lib.rs
@@ -144,7 +144,6 @@ pub mod test_utils {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
     use std::task::{Context, Poll};
-    use std::time::Duration;
     use tower::{Layer, Service, ServiceBuilder};
 
     /// Define a dummy service
@@ -296,11 +295,16 @@ pub mod test_utils {
         /// Gets the current state of results
         pub async fn execute_next(&mut self) -> Option<(TaskId, Result<String, String>)> {
             self.should_next.store(true, Ordering::Release);
-            let res = futures::future::select(
-                self.res_rx.next(),
-                crate::sleep(Duration::from_secs(2)).boxed(),
-            )
-            .await;
+            #[cfg(feature = "sleep")]
+            let fut = async {
+                crate::sleep(std::time::Duration::from_secs(2)).boxed().await;
+            }.boxed();
+            #[cfg(not(feature = "sleep"))]
+            let fut = async {
+                std::future::pending::<()>().await;
+            }.boxed();
+
+            let res = futures::future::select(self.res_rx.next(), fut).await;
             match res {
                 Either::Left(next) => next.0,
                 Either::Right(_) => None,

--- a/packages/apalis-core/src/monitor/mod.rs
+++ b/packages/apalis-core/src/monitor/mod.rs
@@ -118,7 +118,6 @@ impl Monitor {
     /// If a timeout has been set using the `Monitor::shutdown_timeout` method, the monitor
     /// will wait for all workers to complete up to the timeout duration before exiting.
     /// If the timeout is reached and workers have not completed, the monitor will exit forcefully.
-
     pub async fn run_with_signal<S>(self, signal: S) -> std::io::Result<()>
     where
         S: Send + Future<Output = std::io::Result<()>>,

--- a/packages/apalis-core/src/task/task_id.rs
+++ b/packages/apalis-core/src/task/task_id.rs
@@ -68,7 +68,7 @@ impl<Req, Ctx> FromRequest<Request<Req, Ctx>> for TaskId {
 
 struct TaskIdVisitor;
 
-impl<'de> Visitor<'de> for TaskIdVisitor {
+impl Visitor<'_> for TaskIdVisitor {
     type Value = TaskId;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/packages/apalis-sql/src/sqlite.rs
+++ b/packages/apalis-sql/src/sqlite.rs
@@ -643,7 +643,6 @@ mod tests {
 
     use super::*;
     use apalis_core::request::State;
-    use apalis_core::test_utils::DummyService;
     use chrono::Utc;
     use email_service::example_good_email;
     use email_service::Email;


### PR DESCRIPTION
- Removes some requirements for `apalis-core/default`