### PR TITLE
fix: Add migration to drop old push_jobs function for postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **PostgresStorage**: remove old, conflicting apalis.push_job database function ([#543](https://github.com/geofmureithi/apalis/pull/543))
+
 ## [0.7.0](https://github.com/geofmureithi/apalis/releases/tag/v0.7.0)
 
 ### Added

--- a/packages/apalis-sql/migrations/postgres/20250404160441_cleanup_old_push_jobs_fn.sql
+++ b/packages/apalis-sql/migrations/postgres/20250404160441_cleanup_old_push_jobs_fn.sql
@@ -1,0 +1,7 @@
+DROP FUNCTION IF EXISTS apalis.push_job(
+    job_type text,
+    job json,
+    status text,
+    run_at timestamptz,
+    max_attempts integer,
+);

--- a/packages/apalis-sql/migrations/postgres/20250404160441_cleanup_old_push_jobs_fn.sql
+++ b/packages/apalis-sql/migrations/postgres/20250404160441_cleanup_old_push_jobs_fn.sql
@@ -3,5 +3,5 @@ DROP FUNCTION IF EXISTS apalis.push_job(
     job json,
     status text,
     run_at timestamptz,
-    max_attempts integer,
+    max_attempts integer
 );


### PR DESCRIPTION
When i added priority support in https://github.com/geofmureithi/apalis/pull/533 I added a new `apalis.push_job` function for postgres because it had a new parameter, so the old one still exists, which causes problems if calling the function without specifying the priority to distinguish them. Dropping the old one will allow old calls to successfully call the new one. 

The issue should only be affecting calls to the function direclty in sql, not via the apalis library, as those do all specify priority.

Tested with a local project, the migration runs and calling the function as before works now.