### PR TITLE
fix(tests): avoid execute_next timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project are documented in this file.
 - **PostgresStorage**: remove old, conflicting apalis.push_job database function ([#543](https://github.com/geofmureithi/apalis/pull/543))
 - **deps**: update rust crate sentry-core to `0.37.0` ([#542](https://github.com/geofmureithi/apalis/pull/542))
 
+### Tests
+- **execute_next**: fix(tests): avoid execute_next timeout ([#548](https://github.com/geofmureithi/apalis/pull/548))
+
 ## [0.7.0](https://github.com/geofmureithi/apalis/releases/tag/v0.7.0)
 
 ### Added

--- a/packages/apalis-core/src/lib.rs
+++ b/packages/apalis-core/src/lib.rs
@@ -295,24 +295,7 @@ pub mod test_utils {
         /// Gets the current state of results
         pub async fn execute_next(&mut self) -> Option<(TaskId, Result<String, String>)> {
             self.should_next.store(true, Ordering::Release);
-            #[cfg(feature = "sleep")]
-            let fut = async {
-                crate::sleep(std::time::Duration::from_secs(2))
-                    .boxed()
-                    .await;
-            }
-            .boxed();
-            #[cfg(not(feature = "sleep"))]
-            let fut = async {
-                std::future::pending::<()>().await;
-            }
-            .boxed();
-
-            let res = futures::future::select(self.res_rx.next(), fut).await;
-            match res {
-                Either::Left(next) => next.0,
-                Either::Right(_) => None,
-            }
+            self.res_rx.next().await
         }
 
         /// Gets the current state of results

--- a/packages/apalis-core/src/lib.rs
+++ b/packages/apalis-core/src/lib.rs
@@ -125,6 +125,7 @@ pub mod interval {
 }
 
 #[cfg(feature = "test-utils")]
+#[allow(unused)]
 /// Test utilities that allows you to test backends
 pub mod test_utils {
     use crate::backend::Backend;
@@ -133,7 +134,7 @@ pub mod test_utils {
     use crate::task::task_id::TaskId;
     use crate::worker::Worker;
     use futures::channel::mpsc::{self, channel, Receiver, Sender, TryRecvError};
-    use futures::future::{BoxFuture, Either};
+    use futures::future::BoxFuture;
     use futures::stream::{Stream, StreamExt};
     use futures::{FutureExt, SinkExt};
     use std::fmt::Debug;


### PR DESCRIPTION
This PR removes the 2 second timeout on test execution.

This means the test user can set their own timeout.