### PR TITLE
Fix #539 and add more postgres storage tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## Fixed
+
+- **PostgresStorage**: fix type error when updating jobs ([#543](https://github.com/geofmureithi/apalis/issues/539))
+
 ## [0.7.1](https://github.com/geofmureithi/apalis/releases/tag/v0.7.1)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project are documented in this file.
 
 ## Fixed
 
-- **PostgresStorage**: fix type error when updating jobs ([#543](https://github.com/geofmureithi/apalis/issues/539))
+- **PostgresStorage**: fix type error when updating jobs ([#539](https://github.com/geofmureithi/apalis/issues/539))
 
 ## [0.7.1](https://github.com/geofmureithi/apalis/releases/tag/v0.7.1)
 

--- a/packages/apalis-sql/src/lib.rs
+++ b/packages/apalis-sql/src/lib.rs
@@ -390,6 +390,15 @@ macro_rules! sql_storage_tests {
         }
 
         #[tokio::test]
+        async fn test_backend_expose_succeeds() {
+            let storage = setup_test_wrapper().await;
+
+            assert!(storage.stats().await.is_ok());
+            assert!(storage.list_jobs(&State::Pending, 1).await.is_ok());
+            assert!(storage.list_workers().await.is_ok());
+        }
+
+        #[tokio::test]
         async fn integration_test_shedule_and_run_job() {
             let current = Utc::now();
             let dur = Duration::from_secs(15);

--- a/packages/apalis-sql/src/postgres.rs
+++ b/packages/apalis-sql/src/postgres.rs
@@ -1098,13 +1098,4 @@ mod tests {
             .expect("failed to fetch next jobs");
         assert!(!jobs.is_empty(), "Worker should fetch the job");
     }
-
-    #[tokio::test]
-    async fn test_backend_expose_succeeds() {
-        let storage: PostgresStorage<Email> = setup().await;
-
-        assert!(storage.stats().await.is_ok());
-        assert!(storage.list_jobs(&State::Pending, 1).await.is_ok());
-        assert!(storage.list_workers().await.is_ok());
-    }
 }

--- a/packages/apalis-sql/src/postgres.rs
+++ b/packages/apalis-sql/src/postgres.rs
@@ -955,20 +955,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_update_job() {
-        let mut storage = setup().await;
-
-        let task_id = push_email(&mut storage, example_email()).await;
-        let mut job = get_job(&mut storage, &task_id).await;
-        job.parts.context.set_status(State::Killed);
-        storage.update(job).await.expect("updating to succeed");
-
-        let job = get_job(&mut storage, &task_id).await;
-        let ctx = job.parts.context;
-        assert_eq!(*ctx.status(), State::Killed);
-    }
-
-    #[tokio::test]
     async fn test_heartbeat_renqueueorphaned_pulse_last_seen_6min() {
         let mut storage = setup().await;
 

--- a/packages/apalis-sql/src/postgres.rs
+++ b/packages/apalis-sql/src/postgres.rs
@@ -1098,4 +1098,13 @@ mod tests {
             .expect("failed to fetch next jobs");
         assert!(!jobs.is_empty(), "Worker should fetch the job");
     }
+
+    #[tokio::test]
+    async fn test_backend_expose_succeeds() {
+        let storage: PostgresStorage<Email> = setup().await;
+
+        assert!(storage.stats().await.is_ok());
+        assert!(storage.list_jobs(&State::Pending, 0).await.is_ok());
+        assert!(storage.list_workers().await.is_ok());
+    }
 }

--- a/packages/apalis-sql/src/postgres.rs
+++ b/packages/apalis-sql/src/postgres.rs
@@ -788,7 +788,7 @@ impl<J: 'static + Serialize + DeserializeOwned + Unpin + Send + Sync> BackendExp
 
     async fn list_workers(&self) -> Result<Vec<Worker<WorkerState>>, Self::Error> {
         let fetch_query =
-            "SELECT id, layers, last_seen FROM apalis.workers WHERE worker_type = $1 ORDER BY last_seen DESC LIMIT 20 OFFSET $2";
+            "SELECT id, layers, cast(extract(epoch from last_seen) as bigint) FROM apalis.workers WHERE worker_type = $1 ORDER BY last_seen DESC LIMIT 20 OFFSET $2";
         let res: Vec<(String, String, i64)> = sqlx::query_as(fetch_query)
             .bind(self.config().namespace())
             .bind(0)
@@ -1104,7 +1104,7 @@ mod tests {
         let storage: PostgresStorage<Email> = setup().await;
 
         assert!(storage.stats().await.is_ok());
-        assert!(storage.list_jobs(&State::Pending, 0).await.is_ok());
+        assert!(storage.list_jobs(&State::Pending, 1).await.is_ok());
         assert!(storage.list_workers().await.is_ok());
     }
 }

--- a/packages/apalis-sql/src/postgres.rs
+++ b/packages/apalis-sql/src/postgres.rs
@@ -621,7 +621,7 @@ where
 
         let mut tx = self.pool.acquire().await?;
         let query =
-                "UPDATE apalis.jobs SET status = $1, attempts = $2, done_at = $3, lock_by = $4, lock_at = $5, last_error = $6, priority = $7 WHERE id = $8";
+                "UPDATE apalis.jobs SET status = $1, attempts = $2, done_at = to_timestamp($3), lock_by = $4, lock_at = to_timestamp($5), last_error = $6, priority = $7 WHERE id = $8";
         sqlx::query(query)
             .bind(status.to_owned())
             .bind(attempts)

--- a/packages/apalis-sql/src/sqlite.rs
+++ b/packages/apalis-sql/src/sqlite.rs
@@ -590,7 +590,7 @@ impl<J: 'static + Serialize + DeserializeOwned + Unpin + Send + Sync> BackendExp
                             COUNT(1) FILTER (WHERE status = 'Killed') AS killed
                         FROM Jobs WHERE job_type = ?";
 
-        let res: (i64, i64, i64, i64, i64, i64) = sqlx::query_as(fetch_query)
+        let res: (i64, i64, i64, i64, i64) = sqlx::query_as(fetch_query)
             .bind(self.get_config().namespace())
             .fetch_one(self.pool())
             .await?;


### PR DESCRIPTION
I have fixed #539 by adding `to_timestamp` conversions on the postgres side. This is a good fix as long as the `done_at` etc. functions return `i64` instead of proper `DateTime` types on the Rust side.

I have added a test for this updating and one that exercises the `BackendExpose` implementation for postgres, both functions did not seem to be tested before. That also uncovered a timestamp-related bug in list_workers which I fixed here too.

Finally, I have added a changelog entry pointing to #539. Feel free to extend this pull request and/or squash-merge.