### PR TITLE
test: add tests for retry layer storage integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ sentry = ["sentry-core", "ulid?/uuid", "uuid"]
 ## Support Prometheus metrics
 prometheus = ["metrics", "metrics-exporter-prometheus"]
 ## Support direct retrying jobs
-retry = ["tower/retry"]
+retry = ["apalis-core/retry"]
 ## Support timeouts on jobs
 timeout = ["tower/timeout"]
 ## 💪 Limit the amount of jobs

--- a/packages/apalis-core/Cargo.toml
+++ b/packages/apalis-core/Cargo.toml
@@ -33,7 +33,8 @@ default = []
 docsrs = ["document-features"]
 sleep = ["futures-timer"]
 json = ["serde_json"]
-test-utils = []
+test-utils = ["retry"]
+retry = ["tower/retry"]
 
 [package.metadata.docs.rs]
 # defines the configuration attribute `docsrs`

--- a/packages/apalis-core/src/retry/mod.rs
+++ b/packages/apalis-core/src/retry/mod.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::sync::Arc;
 use tower::retry::backoff::Backoff;
 
-use apalis_core::{error::Error, request::Request};
+use crate::{error::Error, request::Request};
 
 /// Re-exports from [`tower::retry`]
 pub use tower::retry::*;

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -5,7 +5,9 @@ pub mod prometheus;
 /// Retry job middleware
 #[cfg(feature = "retry")]
 #[cfg_attr(docsrs, doc(cfg(feature = "retry")))]
-pub mod retry;
+pub mod retry {
+    pub use apalis_core::retry::*;
+}
 /// Sentry integration for apalis.
 #[cfg(feature = "sentry")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sentry")))]


### PR DESCRIPTION
This adds tests that check:

#563 and #554 