### PR TITLE
fix(apalis-redis): enable "allow-undeclared-keys" for dragonflydb in `stats.lua`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 ### Fixed
+- **RedisStorage** the `stats` script is now compatible with dragonfly
 - **examples** Prometheus example ([#562](https://github.com/geofmureithi/apalis/pull/562))
 
 ## Fixed

--- a/packages/apalis-redis/lua/stats.lua
+++ b/packages/apalis-redis/lua/stats.lua
@@ -1,3 +1,10 @@
+--!df flags=allow-undeclared-keys
+-- FIXME: The previous line enables undeclared keys for dragonflydb. This is
+-- required because keys get programatically generated in the for loop counting
+-- running jobs. However, accessing undeclared keys is considered a bad practice
+-- by redis:
+-- https://redis.io/docs/latest/commands/eval/#:~:text=Important%3A%20to,in%20the%20database
+
 -- KEYS[1]: the pending jobs set ( aka active job list )
 -- KEYS[2]: the consumer set
 -- KEYS[3]: the dead jobs set

--- a/packages/apalis-redis/lua/stats.lua
+++ b/packages/apalis-redis/lua/stats.lua
@@ -17,8 +17,8 @@ local success_jobs_set = KEYS[5]
 local consumers = redis.call("zrangebyscore", consumer_set, 0, "+inf")
 
 local running_count = 0
-for _,consumer_inlfight_set in ipairs(consumers) do
-  running_count = running_count + redis.call("SCARD", consumer_inlfight_set)
+for _, consumer_inflight_set in ipairs(consumers) do
+    running_count = running_count + redis.call("SCARD", consumer_inflight_set)
 end
 
 local pending_count = redis.call('LLEN', pending_jobs_set)
@@ -26,4 +26,4 @@ local dead_count = redis.call('ZCARD', dead_jobs_set)
 local failed_count = redis.call('ZCARD', failed_jobs_set)
 local success_count = redis.call('ZCARD', success_jobs_set)
 
-return {pending_count, running_count, dead_count, failed_count, success_count}
+return { pending_count, running_count, dead_count, failed_count, success_count }


### PR DESCRIPTION
#506 introduced a bug when using `apalis-redis` with dragonfly DB: Since keys get programatically generated, in the for loop counting running jobs, the script does not work with dragonfly, which forbids using undeclared keys by default: https://www.dragonflydb.io/docs/managing-dragonfly/scripting#allowing-undeclared-keys .

With Redis, accessing undeclared keys is allowed, but considered a bad practice: https://redis.io/docs/latest/commands/eval/#:~:text=Important%3A%20to,in%20the%20database

A long-term fix would probably be something like storing a counter of running jobs somewhere, and pass the key of the counter to the script