### PR TITLE
fix: ease the error type that is returned by a worker function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,7 @@ All notable changes to this project are documented in this file.
 - **deps** : update rust crate redis to 0.31 ([#555](https://github.com/geofmureithi/apalis/pull/555))
 - **deps** : update rust crate sentry-core to 0.38.0 ([#569](https://github.com/geofmureithi/apalis/pull/569))
 - **deps** : update rust crate criterion to 0.6.0 ([#574](https://github.com/geofmureithi/apalis/pull/574))
-
-
-## Fixed
-
+- **error-handling** : ease the error type that is returned by a worker function ([#577](https://github.com/geofmureithi/apalis/pull/577))
 - **PostgresStorage**: fix type error when updating jobs ([#539](https://github.com/geofmureithi/apalis/issues/539))
 
 ## [0.7.1](https://github.com/geofmureithi/apalis/releases/tag/v0.7.1)

--- a/examples/basics/src/main.rs
+++ b/examples/basics/src/main.rs
@@ -30,18 +30,6 @@ async fn produce_jobs(storage: &SqliteStorage<Email>) {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum ServiceError {
-    #[error("data store disconnected")]
-    Disconnect(#[from] std::io::Error),
-    #[error("the data for key `{0}` is not available")]
-    Redaction(String),
-    #[error("invalid header (expected {expected:?}, found {found:?})")]
-    InvalidHeader { expected: String, found: String },
-    #[error("unknown data store error")]
-    Unknown,
-}
-
-#[derive(thiserror::Error, Debug)]
 pub enum PanicError {
     #[error("{0}")]
     Panic(String),
@@ -54,7 +42,7 @@ async fn send_email(
     svc: Data<EmailService>,
     worker: Worker<Context>,
     cache: Data<ValidEmailCache>,
-) -> Result<(), ServiceError> {
+) -> Result<(), BoxDynError> {
     info!("Job started in worker {:?}", worker.id());
     let cache_clone = cache.clone();
     let email_to = email.to.clone();


### PR DESCRIPTION
- This allows use of more error types like `BoxDynError` and `anyhow::Error`

Now you can do:
```rs
async fn send_email(task: Email) -> anyhow::Result<()> {
     bail!("Email not sent")
}
```

Resolves #470 