### PR TITLE
Add IF NOT EXISTS and equivalents to postgres migrations

### DIFF
--- a/packages/apalis-sql/migrations/postgres/20220530084123_jobs_workers.sql
+++ b/packages/apalis-sql/migrations/postgres/20220530084123_jobs_workers.sql
@@ -79,5 +79,5 @@
             END;
         $$ language plpgsql;
 
-        CREATE TRIGGER notify_workers after insert on apalis.jobs for each statement execute procedure apalis.notify_new_jobs();
+        CREATE OR REPLACE TRIGGER notify_workers after insert on apalis.jobs for each statement execute procedure apalis.notify_new_jobs();
 

--- a/packages/apalis-sql/migrations/postgres/20220530084123_jobs_workers.sql
+++ b/packages/apalis-sql/migrations/postgres/20220530084123_jobs_workers.sql
@@ -1,4 +1,4 @@
-    CREATE SCHEMA apalis;
+    CREATE SCHEMA IF NOT EXISTS apalis;
     
     CREATE TABLE IF NOT EXISTS apalis.workers (
         id TEXT NOT NULL,

--- a/packages/apalis-sql/migrations/postgres/20220530084123_jobs_workers.sql
+++ b/packages/apalis-sql/migrations/postgres/20220530084123_jobs_workers.sql
@@ -72,7 +72,7 @@
         END;
         $$ LANGUAGE plpgsql volatile;
 
-        CREATE FUNCTION apalis.notify_new_jobs() returns trigger as $$
+        CREATE OR REPLACE FUNCTION apalis.notify_new_jobs() returns trigger as $$
             BEGIN
                  perform pg_notify('apalis::job', 'insert');
                  return new;

--- a/packages/apalis-sql/migrations/postgres/20250307001101_add_job_priority.sql
+++ b/packages/apalis-sql/migrations/postgres/20250307001101_add_job_priority.sql
@@ -1,5 +1,5 @@
 ALTER TABLE apalis.jobs
-ADD COLUMN priority INTEGER DEFAULT 0;
+ADD COLUMN IF NOT EXISTS priority INTEGER DEFAULT 0;
 
 DROP FUNCTION apalis.get_jobs(
         worker_id TEXT,


### PR DESCRIPTION
The postgres backend errors out on subsequent migration applications. This adds the necessary conditions to gracefully skip over already applied migrations.