### PR TITLE
Fix PostgreSQL schema creation to be idempotent

### DIFF
--- a/packages/apalis-sql/migrations/postgres/20220530084123_jobs_workers.sql
+++ b/packages/apalis-sql/migrations/postgres/20220530084123_jobs_workers.sql
@@ -1,4 +1,4 @@
-    CREATE SCHEMA apalis;
+    CREATE SCHEMA IF NOT EXISTS apalis;
     
     CREATE TABLE IF NOT EXISTS apalis.workers (
         id TEXT NOT NULL,


### PR DESCRIPTION
The PostgreSQL migration 20220530084123 creates the apalis schema without the IF NOT EXISTS clause, causing failures when the migration is re-executed.

This PR adds IF NOT EXISTS to the schema creation statement to match the pattern already used by all tables and indexes in the same migration file. This change makes the migration idempotent and safe to run multiple times.

Closes apalis-dev/apalis-postgres#45