### PR TITLE
feat(apalis-sql): add optional time crate support

### DIFF
--- a/apalis-sql/Cargo.toml
+++ b/apalis-sql/Cargo.toml
@@ -20,7 +20,6 @@ apalis-core = { path = "../apalis-core", version = "1.0.0-beta.2", default-featu
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
-chrono = { version = "0.4", features = ["serde"] }
 
 [lints]
 workspace = true

--- a/apalis-sql/src/lib.rs
+++ b/apalis-sql/src/lib.rs
@@ -8,6 +8,8 @@ pub mod context;
 /// SQL task row representation and conversion
 pub mod from_row;
 
+pub use from_row::{SqlTimestamp, TaskRow};
+
 /// Convert a string to a StatType
 #[must_use]
 pub fn stat_type_from_string(s: &str) -> StatType {


### PR DESCRIPTION
## Summary
- Adds `SqlTimestamp` trait for datetime abstraction
- Enables optional `time` crate support alongside default `chrono`

Ref: apalis-dev/apalis#649