### PR TITLE
feat: add encryption example with AES-256-GCM job envelopes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,7 +381,7 @@ dependencies = [
  "apalis-file-storage",
  "futures",
  "petgraph",
- "rand",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -624,6 +659,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +709,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +731,26 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "dag-workflow"
@@ -834,6 +908,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "encryption"
+version = "0.1.0"
+dependencies = [
+ "aes-gcm",
+ "apalis",
+ "apalis-core",
+ "pin-project",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1073,6 +1165,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,6 +1208,16 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1484,6 +1596,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,7 +1827,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "metrics",
  "quanta",
- "rand",
+ "rand 0.9.2",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -1989,6 +2110,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,7 +2257,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand",
+ "rand 0.9.2",
  "thiserror 2.0.18",
 ]
 
@@ -2232,6 +2359,18 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2405,12 +2544,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2420,7 +2580,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2438,7 +2607,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2776,7 +2945,7 @@ version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ac170a5bba8bec6e3339c90432569d89641fa7a3d3e4f44987d24f0762e6adf"
 dependencies = [
- "rand",
+ "rand 0.9.2",
  "sentry-types",
  "serde",
  "serde_json",
@@ -2853,7 +3022,7 @@ checksum = "56780cb5597d676bf22e6c11d1f062eb4def46390ea3bfb047bcbcf7dfd19bdb"
 dependencies = [
  "debugid",
  "hex",
- "rand",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3420,12 +3589,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "ulid"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand",
+ "rand 0.9.2",
  "uuid",
  "web-time",
 ]
@@ -3456,6 +3631,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "unmonitored-worker"

--- a/examples/encryption/Cargo.toml
+++ b/examples/encryption/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "encryption"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+apalis = { path = "../../apalis", features = ["limit", "catch-panic", "tracing"] }
+apalis-core = { path = "../../apalis-core", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing-subscriber = "0.3"
+tracing = "0.1"
+tower = "0.5"
+pin-project = "1"
+thiserror = "2"
+
+# Encryption
+aes-gcm = "0.10"
+rand = "0.8"

--- a/examples/encryption/src/lib.rs
+++ b/examples/encryption/src/lib.rs
@@ -1,0 +1,186 @@
+use std::{fmt::Debug, marker::PhantomData, sync::Arc};
+
+use aes_gcm::{
+    Aes256Gcm, Key, Nonce,
+    aead::{Aead, AeadCore, KeyInit, OsRng},
+};
+use apalis_core::{error::BoxDynError, task::Task};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use tower::Service;
+
+const NONCE_SIZE: usize = 12;
+
+#[derive(Debug, thiserror::Error)]
+pub enum EncryptionError {
+    #[error("encryption failed: {0}")]
+    Encrypt(String),
+    #[error("decryption failed: {0}")]
+    Decrypt(String),
+    #[error("serialization failed: {0}")]
+    Serialize(#[from] serde_json::Error),
+    #[error("payload too short to contain nonce")]
+    PayloadTooShort,
+}
+
+#[derive(Clone)]
+pub struct EncryptionKey {
+    cipher: Arc<Aes256Gcm>,
+}
+
+impl Debug for EncryptionKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EncryptionKey")
+            .field("cipher", &"<redacted>")
+            .finish()
+    }
+}
+
+impl EncryptionKey {
+    pub fn generate() -> Self {
+        let key = Aes256Gcm::generate_key(&mut OsRng);
+        Self {
+            cipher: Arc::new(Aes256Gcm::new(&key)),
+        }
+    }
+
+    pub fn from_bytes(key_bytes: &[u8; 32]) -> Self {
+        let key = Key::<Aes256Gcm>::from_slice(key_bytes);
+        Self {
+            cipher: Arc::new(Aes256Gcm::new(key)),
+        }
+    }
+
+    fn encrypt(&self, plaintext: &[u8]) -> Result<Vec<u8>, EncryptionError> {
+        let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+        let ciphertext = self
+            .cipher
+            .encrypt(&nonce, plaintext)
+            .map_err(|e| EncryptionError::Encrypt(e.to_string()))?;
+        let mut output = Vec::with_capacity(NONCE_SIZE + ciphertext.len());
+        output.extend_from_slice(&nonce);
+        output.extend_from_slice(&ciphertext);
+        Ok(output)
+    }
+
+    fn decrypt(&self, data: &[u8]) -> Result<Vec<u8>, EncryptionError> {
+        if data.len() < NONCE_SIZE {
+            return Err(EncryptionError::PayloadTooShort);
+        }
+        let (nonce_bytes, ciphertext) = data.split_at(NONCE_SIZE);
+        let nonce = Nonce::from_slice(nonce_bytes);
+        self.cipher
+            .decrypt(nonce, ciphertext)
+            .map_err(|e| EncryptionError::Decrypt(e.to_string()))
+    }
+}
+
+/// An encrypted job envelope that preserves the original job type `T` for routing
+/// while storing the payload as encrypted bytes.
+///
+/// The type parameter `T` is never stored directly — it exists only as a phantom
+/// so that `EncryptedJob<Email>` and `EncryptedJob<Report>` are distinct types,
+/// giving each its own queue name for backend routing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EncryptedJob<T> {
+    payload: Vec<u8>,
+    #[serde(skip)]
+    _marker: PhantomData<T>,
+}
+
+impl<T: Serialize> EncryptedJob<T> {
+    pub fn seal(key: &EncryptionKey, job: &T) -> Result<Self, EncryptionError> {
+        let plaintext = serde_json::to_vec(job)?;
+        let payload = key.encrypt(&plaintext)?;
+        Ok(Self {
+            payload,
+            _marker: PhantomData,
+        })
+    }
+}
+
+impl<T: DeserializeOwned> EncryptedJob<T> {
+    pub fn open(&self, key: &EncryptionKey) -> Result<T, EncryptionError> {
+        let plaintext = key.decrypt(&self.payload)?;
+        serde_json::from_slice(&plaintext).map_err(EncryptionError::Serialize)
+    }
+}
+
+/// Encrypts a job and pushes it to the backend.
+///
+/// The backend must accept `EncryptedJob<T>` as its `Args` type.
+pub async fn push_encrypted<T, B>(
+    backend: &mut B,
+    key: &EncryptionKey,
+    job: T,
+) -> Result<(), BoxDynError>
+where
+    T: Serialize + Send,
+    B: apalis_core::backend::TaskSink<EncryptedJob<T>>,
+    B::Error: std::error::Error + Send + Sync + 'static,
+{
+    let encrypted = EncryptedJob::seal(key, &job)?;
+    backend.push(encrypted).await?;
+    Ok(())
+}
+
+/// A `Service` that accepts `Task<EncryptedJob<T>>`, decrypts it, and delegates
+/// to an inner handler function that works with the plaintext `T`.
+///
+/// Pass this directly to `WorkerBuilder::build()`:
+/// ```ignore
+/// WorkerBuilder::new("worker")
+///     .backend(storage)  // MemoryStorage<EncryptedJob<Email>>
+///     .build(DecryptService::new(key, handle_email))
+/// ```
+#[derive(Debug, Clone)]
+pub struct DecryptService<F, T> {
+    key: EncryptionKey,
+    handler: F,
+    _marker: PhantomData<T>,
+}
+
+impl<F, T> DecryptService<F, T> {
+    pub fn new(key: EncryptionKey, handler: F) -> Self {
+        Self {
+            key,
+            handler,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<F, T, Fut, Ctx, IdType> Service<Task<EncryptedJob<T>, Ctx, IdType>> for DecryptService<F, T>
+where
+    F: FnMut(T) -> Fut + Clone,
+    Fut: std::future::Future + Send + 'static,
+    Fut::Output: apalis_core::task_fn::IntoResponse,
+    T: DeserializeOwned,
+{
+    type Response = <Fut::Output as apalis_core::task_fn::IntoResponse>::Output;
+    type Error = BoxDynError;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
+    >;
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, task: Task<EncryptedJob<T>, Ctx, IdType>) -> Self::Future {
+        match task.args.open(&self.key) {
+            Ok(decrypted) => {
+                let fut = (self.handler.clone())(decrypted);
+                Box::pin(async move {
+                    use apalis_core::task_fn::IntoResponse;
+                    fut.await.into_response()
+                })
+            }
+            Err(e) => Box::pin(async move { Err(e.into()) }),
+        }
+    }
+}
+
+

--- a/examples/encryption/src/main.rs
+++ b/examples/encryption/src/main.rs
@@ -1,0 +1,77 @@
+use apalis::prelude::*;
+use encryption::{DecryptService, EncryptedJob, EncryptionKey, push_encrypted};
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Email {
+    to: String,
+    subject: String,
+    body: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Report {
+    name: String,
+    quarter: u8,
+}
+
+async fn handle_email(email: Email) -> Result<(), BoxDynError> {
+    info!(to = %email.to, subject = %email.subject, "decrypted and processing email");
+    Ok(())
+}
+
+async fn handle_report(report: Report) -> Result<(), BoxDynError> {
+    info!(name = %report.name, quarter = report.quarter, "decrypted and processing report");
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
+    let key = EncryptionKey::generate();
+
+    let mut email_storage: MemoryStorage<EncryptedJob<Email>> = MemoryStorage::new();
+    let mut report_storage: MemoryStorage<EncryptedJob<Report>> = MemoryStorage::new();
+
+    push_encrypted(
+        &mut email_storage,
+        &key,
+        Email {
+            to: "alice@example.com".to_string(),
+            subject: "Encrypted hello".to_string(),
+            body: "This payload was encrypted at rest".to_string(),
+        },
+    )
+    .await
+    .unwrap();
+
+    push_encrypted(
+        &mut report_storage,
+        &key,
+        Report {
+            name: "Q4 Revenue".to_string(),
+            quarter: 4,
+        },
+    )
+    .await
+    .unwrap();
+
+    info!("pushed encrypted jobs, starting workers...");
+
+    let email_worker = WorkerBuilder::new("email-worker")
+        .backend(email_storage)
+        .build(DecryptService::new(key.clone(), handle_email));
+
+    let report_worker = WorkerBuilder::new("report-worker")
+        .backend(report_storage)
+        .build(DecryptService::new(key, handle_report));
+
+    tokio::select! {
+        res = email_worker.run() => res.unwrap(),
+        res = report_worker.run() => res.unwrap(),
+    }
+}


### PR DESCRIPTION
## Description

Brief description of what this PR does.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the existing tests and they pass
- [ ] I have run `cargo fmt` and `cargo clippy`

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes

I only added an example for an encryption layer. It's useful to avoid storing sesitive data in the db during the processing. Only the producer and consumers can see the unencrypted version of the data.